### PR TITLE
Support for string values and many of BBC BASIC's string functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,12 +179,12 @@ Things like `STA&4000` are permitted with or without `-w`.
 
 `-D <symbol>=<value>`
 
-`-S <symbol>=<string>'
+`-S <symbol>=<string>`
 
 Define `<symbol>` before starting to assemble. If `<value>` is not given, `-1` (`TRUE`)
 will be used by default. Note that there must be a space between `-D` or `-S` and the symbol. `<value>` may be in decimal, hexadecimal (prefixed with $, & or 0x) or binary (prefixed with %).  `<string>` may be quoted.
 
-`-D` and '-S' can be used in conjunction with conditional assignment to provide default values within the source which can be overridden from the command line.
+`-D` and `-S` can be used in conjunction with conditional assignment to provide default values within the source which can be overridden from the command line.
 
 ## 5. SOURCE FILE SYNTAX
 

--- a/README.md
+++ b/README.md
@@ -632,6 +632,10 @@ Abort assembly if any of the expressions is false.
 
 Seed the random number generator used by the RND() function.  If this is not used, the random number generator is seeded based on the current time and so each build of a program using `RND()` will be different.
 
+`ASM <instr>, <params>`
+
+Assemble the instruction with the supplied parameters.  For example `ASM "LDA", "#&41"`.
+
 ## 7. TIPS AND TRICKS
 
 BeebAsm's approach of treating memory as a canvas which can be written to, saved, and rewritten if desired makes it very easy to create certain types of applications.

--- a/README.md
+++ b/README.md
@@ -275,7 +275,7 @@ Note that it is not possible to reassign variables once defined. However `FOR...
 
 Variables can be defined if they are not already defined using the conditional assignment syntax `=?`, e.g. `addr =? &70`. This is useful in conjunction with the `-D` command line option to provide default values for variables in the source while allowing them to be overridden on the command line. (Because variables cannot be reassigned once defined, it is not possible to define a variable with `-D` *and* with non-conditional assignment.)
 
-(Thanks to Stephen Harris <sweh@spuddy.org> and "ctr" for the `-D`/conditional assignment support.)
+(Thanks to Stephen Harris <sweh@spuddy.org> and Charles Reilly for the `-D`/conditional assignment support.)
 
 
 ## 6. ASSEMBLER DIRECTIVES
@@ -728,7 +728,7 @@ There is also a demo called `"relocdemo.asm"`, which shows how the 'reload addre
 ??/??/????  1.10  Documented "$" and "%" as literal prefixes (thanks to
                   cardboardguru76 for pointing this out).
 		  Fixed silently treating label references starting with "."
-		  as 0 (thanks to mungre for this fix).
+		  as 0 (thanks to Charles Reilly for this fix).
 		  Allowed "-h" and "-help" options to see help.
 		  Fixed tokenisation of BASIC pseudo-variables in some cases.
 		  (Thanks to Richard Russell for advice on this.)
@@ -738,6 +738,9 @@ There is also a demo called `"relocdemo.asm"`, which shows how the 'reload addre
 		  Added FILELINE$ and CALLSTACK$ (thanks to tricky for this)
 		  Added -writes, -dd and -labels options (thanks to tricky for these)
 		  Added CMake support and man page (thanks to Dave Lambley)
+		  Added string values and VAL, EVAL, STR$, LEN, CHR$, ASC, MID$,
+		  STRING$, LOWER$, UPPER$, ASM. (Charles Reilly with thanks to
+		  Steven Flintham.)
 12/05/2018  1.09  Added ASSERT
                   Added CPU (as a constant)
                   Added PUTTEXT

--- a/README.md
+++ b/README.md
@@ -384,9 +384,9 @@ Puts a 'guard' on the specified address which will cause an error if you attempt
 Clears all guards between the `<start>` and `<end`> addresses specified.  This can also be used to reset a section of memory which has had code assembled in it previously.  BeebAsm will complain if you attempt to assemble code over previously assembled code at the same address without having `CLEAR`ed it first.
 
 
-`SAVE "filename", start, end [, exec [, reload] ]`
+`SAVE ["filename"], start, end [, exec [, reload] ]`
 
-Saves out object code to either a DFS disc image (if one has been specified), or to the current directory as a standalone file.  A source file must have at least one SAVE statement in it, otherwise nothing will be output.  BeebAsm will warn if this is the case.
+Saves out object code to either a DFS disc image (if one has been specified), or to the current directory as a standalone file.  The filename is optional only if a name is specified with `-o` on the command line.  A source file must have at least one SAVE statement in it, otherwise nothing will be output.  BeebAsm will warn if this is the case.
 
 `'exec'` can be optionally specified as the execution address of the file when saved to a disc image.
 

--- a/README.md
+++ b/README.md
@@ -235,7 +235,22 @@ NOT(val)           Return the bitwise 1's complement of val
 LOG(val)           Return the base 10 log of val
 LN(val)            Return the natural log of val
 EXP(val)           Return e raised to the power of val
+VAL(str)           Return the value of a decimal number in a string
+STR$(val)          Return the number val converted to a string
+LEN(str)           Return the length of str
+CHR$(val)          Return a string with a single character with ASCII value val
+ASC(str)           Return the ASCII value of the first character of str
+MID$(str,index,length)
+                   Return length characters of str starting at (one-based) index
+STRINGS$(count,str)
+                   Return str repeated count times
+TIME$              Return assembly date/time in format "Day,DD Mon Year.HH:MM:SS"
+TIME$("fmt")       Return assembly date/time in a format determined by "fmt", which
+                   is the same format used by the C library strftime()
 ```
+
+The assembly date/time is constant throughout the assembly; every use of `TIME$`
+will return the same date/time.
 
 Also, some constants are defined:
 
@@ -248,19 +263,7 @@ TRUE               Returns -1
 CPU                The value set by the CPU assembler directive (see below)
 ```
 
-Within `EQUB/EQUS` only you can also use the expressions:
-
-```
-TIME$              Return assembly date/time in format "Day,DD Mon Year.HH:MM:SS"
-
-TIME$("fmt")       Return assembly date/time in a format determined by "fmt", which
-                   is the same format used by the C library strftime().
-```
-
-The assembly date/time is constant throughout the assembly; every use of `TIME$`
-will return the same date/time.
-
-Variables can be defined at any point using the BASIC syntax, i.e. `addr = &70`.
+Variables can be defined at any point using the BASIC syntax, i.e. `addr = &70` or `name = "Bob"`.  Quotes in strings are quoted by doubling, e.g. `"a""b"` for the string `a"b`.
 
 Note that it is not possible to reassign variables once defined. However `FOR...NEXT` blocks have their own scope (more on this later).
 

--- a/README.md
+++ b/README.md
@@ -246,6 +246,8 @@ CHR$(val)          Return a string with a single character with ASCII value val
 ASC(str)           Return the ASCII value of the first character of str
 MID$(str,index,length)
                    Return length characters of str starting at (one-based) index
+LEFT$(str,length)  Return the first length characters of str
+RIGHT$(str,length) Return the last length characters of str
 STRING$(count,str)
                    Return str repeated count times
 LOWER$(str)        Return str converted to lowercase
@@ -739,8 +741,8 @@ There is also a demo called `"relocdemo.asm"`, which shows how the 'reload addre
 		  Added -writes, -dd and -labels options (thanks to tricky for these)
 		  Added CMake support and man page (thanks to Dave Lambley)
 		  Added string values and VAL, EVAL, STR$, LEN, CHR$, ASC, MID$,
-		  STRING$, LOWER$, UPPER$, ASM. (Charles Reilly with thanks to
-		  Steven Flintham.)
+		  LEFT$, RIGHT$, STRING$, LOWER$, UPPER$, ASM. (Charles Reilly with
+		  thanks to Steven Flintham.)
 12/05/2018  1.09  Added ASSERT
                   Added CPU (as a constant)
                   Added PUTTEXT

--- a/README.md
+++ b/README.md
@@ -632,9 +632,9 @@ Abort assembly if any of the expressions is false.
 
 Seed the random number generator used by the RND() function.  If this is not used, the random number generator is seeded based on the current time and so each build of a program using `RND()` will be different.
 
-`ASM <instr>, <params>`
+`ASM <str>`
 
-Assemble the instruction with the supplied parameters.  For example `ASM "LDA", "#&41"`.
+Assemble the supplied assembly language string.  For example `ASM "LDA #&41"`.
 
 ## 7. TIPS AND TRICKS
 

--- a/README.md
+++ b/README.md
@@ -246,7 +246,7 @@ CHR$(val)          Return a string with a single character with ASCII value val
 ASC(str)           Return the ASCII value of the first character of str
 MID$(str,index,length)
                    Return length characters of str starting at (one-based) index
-STRINGS$(count,str)
+STRING$(count,str)
                    Return str repeated count times
 LOWER$(str)        Return str converted to lowercase
 UPPER$(str)        Return str converted to uppercase

--- a/README.md
+++ b/README.md
@@ -179,10 +179,12 @@ Things like `STA&4000` are permitted with or without `-w`.
 
 `-D <symbol>=<value>`
 
-Define `<symbol>` before starting to assemble. If `<value>` is not given, `-1` (`TRUE`)
-will be used by default. Note that there must be a space between `-D` and the symbol. `<value>` may be in decimal, hexadecimal (prefixed with $, & or 0x) or binary (prefixed with %).
+`-S <symbol>=<string>'
 
-`-D` can be used in conjunction with conditional assignment to provide default values within the source which can be overridden from the command line.
+Define `<symbol>` before starting to assemble. If `<value>` is not given, `-1` (`TRUE`)
+will be used by default. Note that there must be a space between `-D` or `-S` and the symbol. `<value>` may be in decimal, hexadecimal (prefixed with $, & or 0x) or binary (prefixed with %).  `<string>` may be quoted.
+
+`-D` and '-S' can be used in conjunction with conditional assignment to provide default values within the source which can be overridden from the command line.
 
 ## 5. SOURCE FILE SYNTAX
 

--- a/README.md
+++ b/README.md
@@ -240,6 +240,7 @@ EXP(val)           Return e raised to the power of val
 VAL(str)           Return the value of a decimal number in a string
 EVAL(str)          Return the value of an expression in a string
 STR$(val)          Return the number val converted to a string
+STR$~(val)         Return the number val converted to a string in hexadecimal
 LEN(str)           Return the length of str
 CHR$(val)          Return a string with a single character with ASCII value val
 ASC(str)           Return the ASCII value of the first character of str
@@ -247,6 +248,8 @@ MID$(str,index,length)
                    Return length characters of str starting at (one-based) index
 STRINGS$(count,str)
                    Return str repeated count times
+LOWER$(str)        Return str converted to lowercase
+UPPER$(str)        Return str converted to uppercase
 TIME$              Return assembly date/time in format "Day,DD Mon Year.HH:MM:SS"
 TIME$("fmt")       Return assembly date/time in a format determined by "fmt", which
                    is the same format used by the C library strftime()

--- a/README.md
+++ b/README.md
@@ -238,6 +238,7 @@ LOG(val)           Return the base 10 log of val
 LN(val)            Return the natural log of val
 EXP(val)           Return e raised to the power of val
 VAL(str)           Return the value of a decimal number in a string
+EVAL(str)          Return the value of an expression in a string
 STR$(val)          Return the number val converted to a string
 LEN(str)           Return the length of str
 CHR$(val)          Return a string with a single character with ASCII value val

--- a/examples/stringfunctions.6502
+++ b/examples/stringfunctions.6502
@@ -1,0 +1,26 @@
+org &2000
+.start
+	rts
+.end
+
+save "test", start, end
+
+foo="Foo"
+bar="Bar"
+Foo="fooled!"
+ASSERT foo + " " + bar = "Foo Bar"
+ASSERT MID$(bar, 2, 1) = "a"
+ASSERT UPPER$(foo) = "FOO"
+ASSERT LOWER$(bar) = "bar"
+ASSERT VAL("7.2") = 7.2
+ASSERT EVAL(foo) = "fooled!"
+ASSERT STR$(7.2) = "7.2"
+ASSERT STR$~(27.3) = "1B"
+ASSERT LEN("") = 0
+ASSERT LEN(foo) = 3
+ASSERT LEN("a""b") = 3
+ASSERT CHR$(65) = "A"
+ASSERT ASC(foo) = 70
+ASSERT ASC(MID$("a""b", 2, 1)) = '"'
+ASSERT STRING$(3, bar) = bar + bar + bar
+ASSERT TIME$ = TIME$("%a,%d %b %Y.%H:%M:%S")

--- a/src/VS2010/BeebAsm.vcxproj
+++ b/src/VS2010/BeebAsm.vcxproj
@@ -110,6 +110,7 @@
     <ClInclude Include="..\sourcefile.h" />
     <ClInclude Include="..\stringutils.h" />
     <ClInclude Include="..\symboltable.h" />
+    <ClInclude Include="..\value.h" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/src/VS2010/BeebAsm.vcxproj.filters
+++ b/src/VS2010/BeebAsm.vcxproj.filters
@@ -107,5 +107,8 @@
     <ClInclude Include="..\constants.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="..\value.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
 </Project>

--- a/src/asmexception.h
+++ b/src/asmexception.h
@@ -220,6 +220,7 @@ DEFINE_SYNTAX_EXCEPTION( BadAddress, "Out of range address." );
 DEFINE_SYNTAX_EXCEPTION( BadIndexed, "Syntax error in indexed instruction." );
 DEFINE_SYNTAX_EXCEPTION( NoIndexedX, "X indexed mode does not exist for this instruction." );
 DEFINE_SYNTAX_EXCEPTION( NoIndexedY, "Y indexed mode does not exist for this instruction." );
+DEFINE_SYNTAX_EXCEPTION( MissingAssemblyInstruction, "Expected an assembly language instruction." );
 DEFINE_SYNTAX_EXCEPTION( LabelAlreadyDefined, "Symbol already defined." );
 DEFINE_SYNTAX_EXCEPTION( InvalidSymbolName, "Invalid symbol name; must start with a letter and contain only letters, numbers and underscore." );
 DEFINE_SYNTAX_EXCEPTION( SymbolScopeOutsideMacro, "Symbol scope cannot promote outside current macro." );

--- a/src/asmexception.h
+++ b/src/asmexception.h
@@ -201,6 +201,7 @@ DEFINE_SYNTAX_EXCEPTION( MissingQuote, "Unterminated string." );
 DEFINE_SYNTAX_EXCEPTION( MissingComma, "Missing comma." );
 DEFINE_SYNTAX_EXCEPTION( IllegalOperation, "Operation attempted with invalid or out of range values." );
 DEFINE_SYNTAX_EXCEPTION( TimeResultTooBig, "TIME$() result too big." );
+DEFINE_SYNTAX_EXCEPTION( ParameterCount, "Wrong number of parameters." );
 
 // assembler parsing exceptions
 DEFINE_SYNTAX_EXCEPTION( NoImplied, "Implied mode not allowed for this instruction." );

--- a/src/asmexception.h
+++ b/src/asmexception.h
@@ -248,6 +248,7 @@ DEFINE_SYNTAX_EXCEPTION( OutOfRange, "Out of range." );
 DEFINE_SYNTAX_EXCEPTION( BackwardsSkip, "Attempted to skip backwards to an address." );
 DEFINE_SYNTAX_EXCEPTION( NoAnonSave, "Cannot specify SAVE without a filename if no default output filename has been specified." );
 DEFINE_SYNTAX_EXCEPTION( OnlyOneAnonSave, "Can only use SAVE without a filename once per project." );
+DEFINE_SYNTAX_EXCEPTION( TypeMismatch, "Type mismatch." );
 
 
 

--- a/src/assemble.cpp
+++ b/src/assemble.cpp
@@ -182,6 +182,39 @@ int LineParser::GetInstructionAndAdvanceColumn()
 }
 
 
+/*************************************************************************************************/
+/**
+	LineParser::GetInstructionExact()
+
+	Searches for an exact match for the supplied instruction.
+
+	@param		instr			The string containing an instruction
+
+	@return		The token number, or -1 for "not found"
+
+*/
+/*************************************************************************************************/
+int LineParser::GetInstructionExact(const char* instr)
+{
+	for ( int i = 0; i < static_cast<int>( sizeof m_gaOpcodeTable / sizeof( OpcodeData ) ); i++ )
+	{
+		int			cpu		= m_gaOpcodeTable[ i ].m_cpu;
+		const char*	token	= m_gaOpcodeTable[ i ].m_pName;
+
+		// ignore instructions not for current cpu
+		if ( cpu > ObjectCode::Instance().GetCPU() )
+			continue;
+
+		// see if token matches
+		if (stricmp(instr, token) == 0)
+		{
+			return i;
+		}
+	}
+
+	return -1;
+}
+
 
 /*************************************************************************************************/
 /**

--- a/src/assemble.cpp
+++ b/src/assemble.cpp
@@ -117,6 +117,21 @@ const LineParser::OpcodeData	LineParser::m_gaOpcodeTable[] =
 
 #undef X
 
+/*************************************************************************************************/
+/**
+	LineParser::GetInstructionAndAdvanceColumn()
+
+	Searches for an instruction match in the current line, starting at the current column,
+	and moves the column pointer past the token
+
+	@return		The token number, or -1 for "not found"
+				column is modified to index the character after the token
+*/
+/*************************************************************************************************/
+int LineParser::GetInstructionAndAdvanceColumn()
+{
+	return GetInstructionAndAdvanceColumn(GlobalData::Instance().RequireDistinctOpcodes());
+}
 
 /*************************************************************************************************/
 /**
@@ -125,14 +140,13 @@ const LineParser::OpcodeData	LineParser::m_gaOpcodeTable[] =
 	Searches for an instruction match in the current line, starting at the current column,
 	and moves the column pointer past the token
 
-	@param		line			The string to parse
-	@param		column			The column to start from
+	@param		requireDistinctOpcodes	If true, check the opcode is a complete token
 
 	@return		The token number, or -1 for "not found"
 				column is modified to index the character after the token
 */
 /*************************************************************************************************/
-int LineParser::GetInstructionAndAdvanceColumn()
+int LineParser::GetInstructionAndAdvanceColumn(bool requireDistinctOpcodes)
 {
 	for ( int i = 0; i < static_cast<int>( sizeof m_gaOpcodeTable / sizeof( OpcodeData ) ); i++ )
 	{
@@ -159,7 +173,7 @@ int LineParser::GetInstructionAndAdvanceColumn()
 		// The token matches so far, but (optionally) check there's nothing after it; this prevents 
 		// false matches where a macro name begins with an opcode, at the cost of disallowing 
 		// things like "foo=&70:stafoo".
-		if ( GlobalData::Instance().RequireDistinctOpcodes() && bMatch )
+		if ( requireDistinctOpcodes && bMatch )
 		{
 			std::string::size_type k = m_column + len;
 			if ( k < m_line.length() )
@@ -174,50 +188,6 @@ int LineParser::GetInstructionAndAdvanceColumn()
 		if ( bMatch )
 		{
 			m_column += len;
-			return i;
-		}
-	}
-
-	return -1;
-}
-
-
-/*************************************************************************************************/
-/**
-	LineParser::GetInstructionExact()
-
-	Searches for an exact match for the supplied instruction.
-
-	@param		instr			The string containing an instruction
-
-	@return		The token number, or -1 for "not found"
-
-*/
-/*************************************************************************************************/
-int LineParser::GetInstructionExact(const char* instr)
-{
-	for ( int i = 0; i < static_cast<int>( sizeof m_gaOpcodeTable / sizeof( OpcodeData ) ); i++ )
-	{
-		int			cpu		= m_gaOpcodeTable[ i ].m_cpu;
-		const char*	token	= m_gaOpcodeTable[ i ].m_pName;
-		size_t		len		= strlen( token );
-
-		// ignore instructions not for current cpu
-		if ( cpu > ObjectCode::Instance().GetCPU() )
-			continue;
-
-		bool bMatch = true;
-		for ( unsigned int j = 0; j <= len; j++ )
-		{
-			if ( token[ j ] != toupper( instr[ j ] ) )
-			{
-				bMatch = false;
-				break;
-			}
-		}
-
-		if (bMatch)
-		{
 			return i;
 		}
 	}

--- a/src/assemble.cpp
+++ b/src/assemble.cpp
@@ -206,7 +206,7 @@ int LineParser::GetInstructionExact(const char* instr)
 			continue;
 
 		// see if token matches
-		if (stricmp(instr, token) == 0)
+		if (_stricmp(instr, token) == 0)
 		{
 			return i;
 		}

--- a/src/assemble.cpp
+++ b/src/assemble.cpp
@@ -200,13 +200,23 @@ int LineParser::GetInstructionExact(const char* instr)
 	{
 		int			cpu		= m_gaOpcodeTable[ i ].m_cpu;
 		const char*	token	= m_gaOpcodeTable[ i ].m_pName;
+		size_t		len		= strlen( token );
 
 		// ignore instructions not for current cpu
 		if ( cpu > ObjectCode::Instance().GetCPU() )
 			continue;
 
-		// see if token matches
-		if (_stricmp(instr, token) == 0)
+		bool bMatch = true;
+		for ( unsigned int j = 0; j <= len; j++ )
+		{
+			if ( token[ j ] != toupper( instr[ j ] ) )
+			{
+				bMatch = false;
+				break;
+			}
+		}
+
+		if (bMatch)
 		{
 			return i;
 		}

--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -2134,41 +2134,11 @@ void LineParser::HandleRandomize()
 /*************************************************************************************************/
 void LineParser::HandleAsm()
 {
-	// look for mnemonic
+	// look for assembly language string
 
-	Value mnemonic = EvaluateExpression();
+	Value asmValue = EvaluateExpression();
 
-	if (mnemonic.GetType() != Value::StringValue)
-	{
-		throw AsmException_SyntaxError_TypeMismatch( m_line, m_column );
-	}
-
-	int instruction = GetInstructionExact(mnemonic.GetString().Text());
-	if (instruction < 0)
-	{
-		throw AsmException_SyntaxError_UnrecognisedToken( m_line, m_column );
-	}
-
-	// look for comma
-
-	if ( !AdvanceAndCheckEndOfStatement() )
-	{
-		// found nothing
-		throw AsmException_SyntaxError_EmptyExpression( m_line, m_column );
-	}
-
-	if ( m_line[ m_column ] != ',' )
-	{
-		throw AsmException_SyntaxError_InvalidCharacter( m_line, m_column );
-	}
-
-	m_column++;
-
-	// look for end value
-
-	Value paramsValue = EvaluateExpression();
-
-	if (paramsValue.GetType() != Value::StringValue)
+	if (asmValue.GetType() != Value::StringValue)
 	{
 		throw AsmException_SyntaxError_TypeMismatch( m_line, m_column );
 	}
@@ -2180,7 +2150,15 @@ void LineParser::HandleAsm()
 		throw AsmException_SyntaxError_InvalidCharacter( m_line, m_column );
 	}
 
-	String params = paramsValue.GetString();
-	LineParser parser(m_sourceCode, string(params.Text(), params.Length()));
+	String assembly = asmValue.GetString();
+	LineParser parser(m_sourceCode, string(assembly.Text(), assembly.Length()));
+
+	// Parse the mnemonic, don't require a non-alpha after it.
+	int instruction = parser.GetInstructionAndAdvanceColumn(false);
+	if (instruction < 0)
+	{
+		throw AsmException_SyntaxError_UnrecognisedToken( m_line, m_column );
+	}
+
 	parser.HandleAssembler(instruction);
 }

--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -1018,7 +1018,7 @@ void LineParser::HandleSave()
 	{
 		saveFile = string(saveOrStart.GetString().Text(), saveOrStart.GetString().Length());
 
-		if ( m_line[ m_column ] != ',' )
+		if ( m_column >= m_line.length() || m_line[ m_column ] != ',' )
 		{
 			// did not find a comma
 			throw AsmException_SyntaxError_InvalidCharacter( m_line, m_column );

--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -1967,7 +1967,7 @@ void LineParser::HandleAsm()
 	int instruction = parser.GetInstructionAndAdvanceColumn(false);
 	if (instruction < 0)
 	{
-		throw AsmException_SyntaxError_UnrecognisedToken( m_line, m_column );
+		throw AsmException_SyntaxError_MissingAssemblyInstruction( parser.m_line, parser.m_column );
 	}
 
 	parser.HandleAssembler(instruction);

--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -1541,7 +1541,7 @@ void LineParser::HandlePrint()
 					{
 						String text = value.GetString();
 						const char* pstr = text.Text();
-						for (int i = 0; i != text.Length(); ++i)
+						for (unsigned int i = 0; i != text.Length(); ++i)
 						{
 							cout << *pstr;
 							++pstr;

--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -2134,6 +2134,8 @@ void LineParser::HandleRandomize()
 /*************************************************************************************************/
 void LineParser::HandleAsm()
 {
+	// TODO: Better error reporting
+
 	// look for assembly language string
 
 	Value asmValue = EvaluateExpression();

--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -2134,8 +2134,6 @@ void LineParser::HandleRandomize()
 /*************************************************************************************************/
 void LineParser::HandleAsm()
 {
-	// TODO: Better error reporting
-
 	// look for assembly language string
 
 	Value asmValue = EvaluateExpression();

--- a/src/expression.cpp
+++ b/src/expression.cpp
@@ -1484,8 +1484,6 @@ void LineParser::EvalVal()
 /*************************************************************************************************/
 void LineParser::EvalEval()
 {
-	// TODO: Better error reporting
-
 	String expr = StackTopString();
 	LineParser parser(m_sourceCode, string(expr.Text(), expr.Length()));
 	Value result = parser.EvaluateExpression();

--- a/src/expression.cpp
+++ b/src/expression.cpp
@@ -269,9 +269,6 @@ Value LineParser::GetValue()
 		if (symbolName == "TIME$")
 		{
 			// Handle TIME$ with no parameters
-
-			m_column++;
-
 			value = FormatAssemblyTime("%a,%d %b %Y.%H:%M:%S");
 		}
 		else

--- a/src/expression.cpp
+++ b/src/expression.cpp
@@ -45,65 +45,71 @@ using namespace std;
 
 const LineParser::Operator	LineParser::m_gaBinaryOperatorTable[] =
 {
-	{ ")",		-1,	NULL },		// special case
-	{ "]",		-1,	NULL },		// special case
+	{ ")",		-1,	0,	NULL },		// special case
+	{ "]",		-1,	0,	NULL },		// special case
+	{ ",",		-1,	0,	NULL },		// special case
 
-	{ "^",		7,	&LineParser::EvalPower },
-	{ "*",		6,	&LineParser::EvalMultiply },
-	{ "/",		6,	&LineParser::EvalDivide },
-	{ "%",		6,	&LineParser::EvalMod },
-	{ "DIV",	6,	&LineParser::EvalDiv },
-	{ "MOD",	6,	&LineParser::EvalMod },
-	{ "<<",		6,	&LineParser::EvalShiftLeft },
-	{ ">>",		6,	&LineParser::EvalShiftRight },
-	{ "+",		5,	&LineParser::EvalAdd },
-	{ "-",		5,	&LineParser::EvalSubtract },
-	{ "==",		4,	&LineParser::EvalEqual },
-	{ "=",		4,	&LineParser::EvalEqual },
-	{ "<>",		4,	&LineParser::EvalNotEqual },
-	{ "!=",		4,	&LineParser::EvalNotEqual },
-	{ "<=",		4,	&LineParser::EvalLessThanOrEqual },
-	{ ">=",		4,	&LineParser::EvalMoreThanOrEqual },
-	{ "<",		4,	&LineParser::EvalLessThan },
-	{ ">",		4,	&LineParser::EvalMoreThan },
-	{ "AND",	3,	&LineParser::EvalAnd },
-	{ "OR",		2,	&LineParser::EvalOr },
-	{ "EOR",	2,	&LineParser::EvalEor }
+	{ "^",		7,	0,	&LineParser::EvalPower },
+	{ "*",		6,	0,	&LineParser::EvalMultiply },
+	{ "/",		6,	0,	&LineParser::EvalDivide },
+	{ "%",		6,	0,	&LineParser::EvalMod },
+	{ "DIV",	6,	0,	&LineParser::EvalDiv },
+	{ "MOD",	6,	0,	&LineParser::EvalMod },
+	{ "<<",		6,	0,	&LineParser::EvalShiftLeft },
+	{ ">>",		6,	0,	&LineParser::EvalShiftRight },
+	{ "+",		5,	0,	&LineParser::EvalAdd },
+	{ "-",		5,	0,	&LineParser::EvalSubtract },
+	{ "==",		4,	0,	&LineParser::EvalEqual },
+	{ "=",		4,	0,	&LineParser::EvalEqual },
+	{ "<>",		4,	0,	&LineParser::EvalNotEqual },
+	{ "!=",		4,	0,	&LineParser::EvalNotEqual },
+	{ "<=",		4,	0,	&LineParser::EvalLessThanOrEqual },
+	{ ">=",		4,	0,	&LineParser::EvalMoreThanOrEqual },
+	{ "<",		4,	0,	&LineParser::EvalLessThan },
+	{ ">",		4,	0,	&LineParser::EvalMoreThan },
+	{ "AND",	3,	0,	&LineParser::EvalAnd },
+	{ "OR",		2,	0,	&LineParser::EvalOr },
+	{ "EOR",	2,	0,	&LineParser::EvalEor }
 };
 
 
 
 const LineParser::Operator	LineParser::m_gaUnaryOperatorTable[] =
 {
-	{ "(",		-1,	NULL },		// special case
-	{ "[",		-1,	NULL },		// special case
+	{ "(",		-1,	0, NULL },		// special case
+	{ "[",		-1,	0, NULL },		// special case
 
-	{ "-",		8,	&LineParser::EvalNegate },
-	{ "+",		8,	&LineParser::EvalPosate },
-	{ "HI(",	10,	&LineParser::EvalHi },
-	{ "LO(",	10,	&LineParser::EvalLo },
-	{ ">",		10,	&LineParser::EvalHi },
-	{ "<",		10,	&LineParser::EvalLo },
-	{ "SIN(",	10, &LineParser::EvalSin },
-	{ "COS(",	10, &LineParser::EvalCos },
-	{ "TAN(",	10, &LineParser::EvalTan },
-	{ "ASN(",	10, &LineParser::EvalArcSin },
-	{ "ACS(",	10, &LineParser::EvalArcCos },
-	{ "ATN(",	10, &LineParser::EvalArcTan },
-	{ "SQR(",	10, &LineParser::EvalSqrt },
-	{ "RAD(",	10, &LineParser::EvalDegToRad },
-	{ "DEG(",	10, &LineParser::EvalRadToDeg },
-	{ "INT(",	10,	&LineParser::EvalInt },
-	{ "ABS(",	10, &LineParser::EvalAbs },
-	{ "SGN(",	10, &LineParser::EvalSgn },
-	{ "RND(",	10,	&LineParser::EvalRnd },
-	{ "NOT(",	10, &LineParser::EvalNot },
-	{ "LOG(",	10, &LineParser::EvalLog },
-	{ "LN(",	10,	&LineParser::EvalLn },
-	{ "EXP(",	10,	&LineParser::EvalExp },
-	{ "TIME$(",	10,	&LineParser::EvalTime },
-	{ "STR$(",	10,	&LineParser::EvalStr },
-	{ "VAL(",	10,	&LineParser::EvalVal }
+	{ "-",		8,	0,	&LineParser::EvalNegate },
+	{ "+",		8,	0,	&LineParser::EvalPosate },
+	{ "HI(",	10,	1,	&LineParser::EvalHi },
+	{ "LO(",	10,	1,	&LineParser::EvalLo },
+	{ ">",		10,	0,	&LineParser::EvalHi },
+	{ "<",		10,	0,	&LineParser::EvalLo },
+	{ "SIN(",	10, 1,	&LineParser::EvalSin },
+	{ "COS(",	10, 1,	&LineParser::EvalCos },
+	{ "TAN(",	10, 1,	&LineParser::EvalTan },
+	{ "ASN(",	10, 1,	&LineParser::EvalArcSin },
+	{ "ACS(",	10, 1,	&LineParser::EvalArcCos },
+	{ "ATN(",	10, 1,	&LineParser::EvalArcTan },
+	{ "SQR(",	10, 1,	&LineParser::EvalSqrt },
+	{ "RAD(",	10, 1,	&LineParser::EvalDegToRad },
+	{ "DEG(",	10, 1,	&LineParser::EvalRadToDeg },
+	{ "INT(",	10,	1,	&LineParser::EvalInt },
+	{ "ABS(",	10, 1,	&LineParser::EvalAbs },
+	{ "SGN(",	10, 1,	&LineParser::EvalSgn },
+	{ "RND(",	10,	1,	&LineParser::EvalRnd },
+	{ "NOT(",	10, 1,	&LineParser::EvalNot },
+	{ "LOG(",	10, 1,	&LineParser::EvalLog },
+	{ "LN(",	10,	1,	&LineParser::EvalLn },
+	{ "EXP(",	10,	1,	&LineParser::EvalExp },
+	{ "TIME$(",	10,	1,	&LineParser::EvalTime },
+	{ "STR$(",	10,	1,	&LineParser::EvalStr },
+	{ "VAL(",	10,	1,	&LineParser::EvalVal },
+	{ "LEN(",	10,	1,	&LineParser::EvalLen },
+	{ "CHR$(",	10,	1,	&LineParser::EvalChr },
+	{ "ASC(",	10,	1,	&LineParser::EvalAsc },
+	{ "MID$(",	10,	3,	&LineParser::EvalMid },
+	{ "STRING$(",	10,	2,	&LineParser::EvalString }
 };
 
 
@@ -318,11 +324,15 @@ Value LineParser::EvaluateExpression( bool bAllowOneMismatchedCloseBracket )
 
 	int bracketCount = 0;
 
+	// When we know a '(' is coming (because it was the end of a token) this is the number of commas to expect
+	// in the parameter list, i.e. one less than the number of parameters.
+	int pendingCommaCount = 0;
+
 	TYPE expected = VALUE_OR_UNARY;
 
 	// Iterate through the expression
 
-	while ( AdvanceAndCheckEndOfSubStatement() )
+	while ( AdvanceAndCheckEndOfSubStatement(bracketCount == 0) )
 	{
 		if ( expected == VALUE_OR_UNARY )
 		{
@@ -360,6 +370,7 @@ Value LineParser::EvaluateExpression( bool bAllowOneMismatchedCloseBracket )
 
 					if ( len > 1 && token[ len - 1 ] == '(' )
 					{
+						pendingCommaCount = m_gaUnaryOperatorTable[ matchedToken ].parameterCount - 1;
 						m_column--;
 						assert( m_line[ m_column ] == '(' );
 					}
@@ -406,7 +417,7 @@ Value LineParser::EvaluateExpression( bool bAllowOneMismatchedCloseBracket )
 			{
 				// If unary operator *was* found...
 
-				const Operator& thisOp = m_gaUnaryOperatorTable[ matchedToken ];
+				Operator thisOp = m_gaUnaryOperatorTable[ matchedToken ];
 
 				if ( thisOp.handler != NULL )
 				{
@@ -425,6 +436,9 @@ Value LineParser::EvaluateExpression( bool bAllowOneMismatchedCloseBracket )
 				}
 				else
 				{
+					// The open bracket's parameterCount counts down the number of commas expected.
+					thisOp.parameterCount = pendingCommaCount;
+					pendingCommaCount = 0;
 					bracketCount++;
 				}
 
@@ -504,9 +518,14 @@ Value LineParser::EvaluateExpression( bool bAllowOneMismatchedCloseBracket )
 			}
 			else
 			{
-				// is a close bracket
+				// is a close bracket or parameter separator
 
-				bracketCount--;
+				bool separator = strcmp(thisOp.token, ",") == 0;
+
+				if (!separator)
+				{
+					bracketCount--;
+				}
 
 				bool bFoundMatchingBracket = false;
 
@@ -526,8 +545,39 @@ Value LineParser::EvaluateExpression( bool bAllowOneMismatchedCloseBracket )
 					}
 				}
 
-				if ( !bFoundMatchingBracket )
+				if ( bFoundMatchingBracket )
 				{
+					if (separator)
+					{
+						// parameter separator
+
+						// check we are expecting multiple parameters
+						if (m_operatorStack[ m_operatorStackPtr ].parameterCount == 0)
+						{
+							throw AsmException_SyntaxError_ParameterCount( m_line, m_column - 1 );
+						}
+						m_operatorStack[ m_operatorStackPtr ].parameterCount--;
+
+						// put the open bracket back on the stack
+						m_operatorStackPtr++;
+
+						// expect the next parameter
+						expected = VALUE_OR_UNARY;
+					}
+					else
+					{
+						// close par
+
+						// check all parameters have been supplied
+						if (m_operatorStack[ m_operatorStackPtr ].parameterCount != 0)
+						{
+							throw AsmException_SyntaxError_ParameterCount( m_line, m_column - 1 );
+						}
+					}
+				}
+				else
+				{
+					// did not find matching bracket
 					if ( bAllowOneMismatchedCloseBracket )
 					{
 						// this is a hack which allows an extra close bracket to terminate an expression,
@@ -1421,4 +1471,113 @@ void LineParser::EvalVal()
 	double value = strtod(str.Text(), &end);
 
 	m_valueStack[ m_valueStackPtr - 1 ] = value;
+}
+
+
+/*************************************************************************************************/
+/**
+	LineParser::EvalLen()
+*/
+/*************************************************************************************************/
+void LineParser::EvalLen()
+{
+	String str = StackTopString();
+	m_valueStack[ m_valueStackPtr - 1 ] = str.Length();
+}
+
+
+/*************************************************************************************************/
+/**
+	LineParser::EvalChr()
+*/
+/*************************************************************************************************/
+void LineParser::EvalChr()
+{
+	double value = StackTopNumber();
+	int ascii = static_cast<int>(value);
+	if ((ascii < 0) || (ascii > 255))
+	{
+		throw AsmException_SyntaxError_IllegalOperation( m_line, m_column );
+	}
+	char buffer = ascii;
+	m_valueStack[ m_valueStackPtr - 1 ] = String(&buffer, 1);
+}
+
+
+/*************************************************************************************************/
+/**
+	LineParser::EvalAsc()
+*/
+/*************************************************************************************************/
+void LineParser::EvalAsc()
+{
+	String str = StackTopString();
+	if (str.Length() == 0)
+	{
+		throw AsmException_SyntaxError_IllegalOperation( m_line, m_column );
+	}
+
+	m_valueStack[ m_valueStackPtr - 1 ] = static_cast<unsigned char>(str[0]);
+}
+
+
+/*************************************************************************************************/
+/**
+	LineParser::EvalMid()
+*/
+/*************************************************************************************************/
+void LineParser::EvalMid()
+{
+	if ( m_valueStackPtr < 3 )
+	{
+		throw AsmException_SyntaxError_MissingValue( m_line, m_column );
+	}
+	Value value1 = m_valueStack[ m_valueStackPtr - 3 ];
+	Value value2 = m_valueStack[ m_valueStackPtr - 2 ];
+	Value value3 = m_valueStack[ m_valueStackPtr - 1 ];
+	if ((value1.GetType() != Value::StringValue) || (value2.GetType() != Value::NumberValue) || (value3.GetType() != Value::NumberValue))
+	{
+		throw AsmException_SyntaxError_TypeMismatch( m_line, m_column );
+	}
+	m_valueStackPtr -= 2;
+
+	String text = value1.GetString();
+	int index = static_cast<int>(value2.GetNumber()) - 1;
+	int length = static_cast<int>(value3.GetNumber());
+	if ((index < 0) || (static_cast<unsigned int>(index) > text.Length()) || (length < 0))
+	{
+		throw AsmException_SyntaxError_IllegalOperation( m_line, m_column );
+	}
+
+	m_valueStack[ m_valueStackPtr - 1 ] = text.SubString(index, length);
+}
+
+
+/*************************************************************************************************/
+/**
+	LineParser::EvalString()
+*/
+/*************************************************************************************************/
+void LineParser::EvalString()
+{
+	if ( m_valueStackPtr < 2 )
+	{
+		throw AsmException_SyntaxError_MissingValue( m_line, m_column );
+	}
+	Value value1 = m_valueStack[ m_valueStackPtr - 2 ];
+	Value value2 = m_valueStack[ m_valueStackPtr - 1 ];
+	if ((value1.GetType() != Value::NumberValue) || (value2.GetType() != Value::StringValue))
+	{
+		throw AsmException_SyntaxError_TypeMismatch( m_line, m_column );
+	}
+	m_valueStackPtr -= 1;
+
+	int count = static_cast<int>(value1.GetNumber());
+	String text = value2.GetString();
+	if ((count < 0) || (count >= 0x10000) || (text.Length() >= 0x10000) || (static_cast<unsigned int>(count) * text.Length() >= 0x10000))
+	{
+		throw AsmException_SyntaxError_IllegalOperation( m_line, m_column );
+	}
+
+	m_valueStack[ m_valueStackPtr - 1 ] = text.Repeat(count);
 }

--- a/src/expression.cpp
+++ b/src/expression.cpp
@@ -1484,12 +1484,12 @@ void LineParser::EvalVal()
 /*************************************************************************************************/
 void LineParser::EvalEval()
 {
-	String str = StackTopString();
-	// TODO: Evaluate full expression
-	char* end;
-	double value = strtod(str.Text(), &end);
+	// TODO: Better error reporting
 
-	m_valueStack[ m_valueStackPtr - 1 ] = value;
+	String expr = StackTopString();
+	LineParser parser(m_sourceCode, string(expr.Text(), expr.Length()));
+	Value result = parser.EvaluateExpression();
+	m_valueStack[ m_valueStackPtr - 1 ] = result;
 }
 
 

--- a/src/expression.cpp
+++ b/src/expression.cpp
@@ -105,11 +105,14 @@ const LineParser::Operator	LineParser::m_gaUnaryOperatorTable[] =
 	{ "TIME$(",	10,	1,	&LineParser::EvalTime },
 	{ "STR$(",	10,	1,	&LineParser::EvalStr },
 	{ "VAL(",	10,	1,	&LineParser::EvalVal },
+	{ "EVAL(",	10,	1,	&LineParser::EvalEval },
 	{ "LEN(",	10,	1,	&LineParser::EvalLen },
 	{ "CHR$(",	10,	1,	&LineParser::EvalChr },
 	{ "ASC(",	10,	1,	&LineParser::EvalAsc },
 	{ "MID$(",	10,	3,	&LineParser::EvalMid },
-	{ "STRING$(",	10,	2,	&LineParser::EvalString }
+	{ "STRING$(",	10,	2,	&LineParser::EvalString },
+	{ "UPPER(",	10,	1,	&LineParser::EvalUpper },
+	{ "LOWER(",	10,	1,	&LineParser::EvalLower }
 };
 
 
@@ -1476,6 +1479,22 @@ void LineParser::EvalVal()
 
 /*************************************************************************************************/
 /**
+	LineParser::EvalEval()
+*/
+/*************************************************************************************************/
+void LineParser::EvalEval()
+{
+	String str = StackTopString();
+	// TODO: Evaluate full expression
+	char* end;
+	double value = strtod(str.Text(), &end);
+
+	m_valueStack[ m_valueStackPtr - 1 ] = value;
+}
+
+
+/*************************************************************************************************/
+/**
 	LineParser::EvalLen()
 */
 /*************************************************************************************************/
@@ -1580,4 +1599,26 @@ void LineParser::EvalString()
 	}
 
 	m_valueStack[ m_valueStackPtr - 1 ] = text.Repeat(count);
+}
+
+
+/*************************************************************************************************/
+/**
+	LineParser::EvalUpper()
+*/
+/*************************************************************************************************/
+void LineParser::EvalUpper()
+{
+	m_valueStack[ m_valueStackPtr - 1 ] = StackTopString().Upper();
+}
+
+
+/*************************************************************************************************/
+/**
+	LineParser::EvalLower()
+*/
+/*************************************************************************************************/
+void LineParser::EvalLower()
+{
+	m_valueStack[ m_valueStackPtr - 1 ] = StackTopString().Lower();
 }

--- a/src/expression.cpp
+++ b/src/expression.cpp
@@ -677,6 +677,25 @@ unsigned int LineParser::EvaluateExpressionAsUnsignedInt( bool bAllowOneMismatch
 
 /*************************************************************************************************/
 /**
+	LineParser::EvaluateExpressionAsString()
+
+	Version of EvaluateExpression which returns its result as a String or throws a type mismatch
+*/
+/*************************************************************************************************/
+ string LineParser::EvaluateExpressionAsString( bool bAllowOneMismatchedCloseBracket )
+{
+	Value value = EvaluateExpression( bAllowOneMismatchedCloseBracket );
+	if (value.GetType() != Value::StringValue)
+	{
+		throw AsmException_SyntaxError_TypeMismatch( m_line, m_column );
+	}
+	String result = value.GetString();
+	return string(result.Text(), result.Length());
+}
+
+
+/*************************************************************************************************/
+/**
 	LineParser::StackTopTwoValues()
 
 	Retrieve two values of matching type, or throw an exception

--- a/src/expression.cpp
+++ b/src/expression.cpp
@@ -104,6 +104,7 @@ const LineParser::Operator	LineParser::m_gaUnaryOperatorTable[] =
 	{ "EXP(",	10,	1,	&LineParser::EvalExp },
 	{ "TIME$(",	10,	1,	&LineParser::EvalTime },
 	{ "STR$(",	10,	1,	&LineParser::EvalStr },
+	{ "STR$~(",	10,	1,	&LineParser::EvalStrHex },
 	{ "VAL(",	10,	1,	&LineParser::EvalVal },
 	{ "EVAL(",	10,	1,	&LineParser::EvalEval },
 	{ "LEN(",	10,	1,	&LineParser::EvalLen },
@@ -111,8 +112,8 @@ const LineParser::Operator	LineParser::m_gaUnaryOperatorTable[] =
 	{ "ASC(",	10,	1,	&LineParser::EvalAsc },
 	{ "MID$(",	10,	3,	&LineParser::EvalMid },
 	{ "STRING$(",	10,	2,	&LineParser::EvalString },
-	{ "UPPER(",	10,	1,	&LineParser::EvalUpper },
-	{ "LOWER(",	10,	1,	&LineParser::EvalLower }
+	{ "UPPER$(",	10,	1,	&LineParser::EvalUpper },
+	{ "LOWER$(",	10,	1,	&LineParser::EvalLower }
 };
 
 
@@ -1456,6 +1457,21 @@ void LineParser::EvalStr()
 {
 	ostringstream stream;
 	stream << StackTopNumber();
+	string result = stream.str();
+
+	m_valueStack[ m_valueStackPtr - 1 ] = String(result.data(), result.length());
+}
+
+
+/*************************************************************************************************/
+/**
+	LineParser::EvalStrHex()
+*/
+/*************************************************************************************************/
+void LineParser::EvalStrHex()
+{
+	ostringstream stream;
+	stream << std::hex << std::uppercase << static_cast<int>(StackTopNumber());
 	string result = stream.str();
 
 	m_valueStack[ m_valueStackPtr - 1 ] = String(result.data(), result.length());

--- a/src/expression.cpp
+++ b/src/expression.cpp
@@ -262,7 +262,7 @@ Value LineParser::GetValue()
 		int oldColumn = m_column;
 		string symbolName = GetSymbolName();
 
-		if ((m_column < m_line.length()) && (m_line[m_column] == '$') && (symbolName == "TIME"))
+		if (symbolName == "TIME$")
 		{
 			// Handle TIME$ with no parameters
 

--- a/src/expression.cpp
+++ b/src/expression.cpp
@@ -111,6 +111,8 @@ const LineParser::Operator	LineParser::m_gaUnaryOperatorTable[] =
 	{ "CHR$(",	10,	1,	&LineParser::EvalChr },
 	{ "ASC(",	10,	1,	&LineParser::EvalAsc },
 	{ "MID$(",	10,	3,	&LineParser::EvalMid },
+	{ "LEFT$(",	10,	2,	&LineParser::EvalLeft },
+	{ "RIGHT$(",	10,	2,	&LineParser::EvalRight },
 	{ "STRING$(",	10,	2,	&LineParser::EvalString },
 	{ "UPPER$(",	10,	1,	&LineParser::EvalUpper },
 	{ "LOWER$(",	10,	1,	&LineParser::EvalLower }
@@ -1599,6 +1601,67 @@ void LineParser::EvalMid()
 	}
 
 	m_valueStack[ m_valueStackPtr - 1 ] = text.SubString(index, length);
+}
+
+
+/*************************************************************************************************/
+/**
+	LineParser::EvalLeft()
+*/
+/*************************************************************************************************/
+void LineParser::EvalLeft()
+{
+	if ( m_valueStackPtr < 2 )
+	{
+		throw AsmException_SyntaxError_MissingValue( m_line, m_column );
+	}
+	Value value1 = m_valueStack[ m_valueStackPtr - 2 ];
+	Value value2 = m_valueStack[ m_valueStackPtr - 1 ];
+	if ((value1.GetType() != Value::StringValue) || (value2.GetType() != Value::NumberValue))
+	{
+		throw AsmException_SyntaxError_TypeMismatch( m_line, m_column );
+	}
+	m_valueStackPtr -= 1;
+
+	String text = value1.GetString();
+	int count = static_cast<int>(value2.GetNumber());
+	if ((count < 0) || (static_cast<unsigned int>(count) > text.Length()))
+	{
+		throw AsmException_SyntaxError_IllegalOperation( m_line, m_column );
+	}
+
+	m_valueStack[ m_valueStackPtr - 1 ] = text.SubString(0, count);
+}
+
+
+/*************************************************************************************************/
+/**
+	LineParser::EvalRight()
+*/
+/*************************************************************************************************/
+void LineParser::EvalRight()
+{
+	if ( m_valueStackPtr < 2 )
+	{
+		throw AsmException_SyntaxError_MissingValue( m_line, m_column );
+	}
+	Value value1 = m_valueStack[ m_valueStackPtr - 2 ];
+	Value value2 = m_valueStack[ m_valueStackPtr - 1 ];
+	if ((value1.GetType() != Value::StringValue) || (value2.GetType() != Value::NumberValue))
+	{
+		throw AsmException_SyntaxError_TypeMismatch( m_line, m_column );
+	}
+	m_valueStackPtr -= 1;
+
+	String text = value1.GetString();
+	int count = static_cast<int>(value2.GetNumber());
+	if ((count < 0) || (static_cast<unsigned int>(count) > text.Length()))
+	{
+		throw AsmException_SyntaxError_IllegalOperation( m_line, m_column );
+	}
+
+	unsigned int ucount = static_cast<unsigned int>(count);
+	m_valueStack[ m_valueStackPtr - 1 ] = text.SubString(text.Length() - ucount, ucount);
 }
 
 

--- a/src/expression.cpp
+++ b/src/expression.cpp
@@ -927,6 +927,28 @@ void LineParser::EvalMod()
 
 /*************************************************************************************************/
 /**
+	Shifting helper functions
+*/
+/*************************************************************************************************/
+static int LogicalShiftLeft(int value, unsigned int shift)
+{
+	return static_cast<int>(static_cast<unsigned int>(value) << shift);
+}
+
+static int ArithmeticShiftRight(int value, unsigned int shift)
+{
+	unsigned int shifted = static_cast<unsigned int>(value) >> shift;
+	if (value < 0)
+	{
+		const unsigned int bitcount = 8 * sizeof(unsigned int);
+		const unsigned int ones = ~0;
+		shifted |= (ones << (bitcount - shift));
+	}
+	return static_cast<int>(shifted);
+}
+
+/*************************************************************************************************/
+/**
 	LineParser::EvalShiftLeft()
 */
 /*************************************************************************************************/
@@ -944,7 +966,7 @@ void LineParser::EvalShiftLeft()
 	}
 	else if ( shift > 0 )
 	{
-		result = val << shift;
+		result = LogicalShiftLeft(val, static_cast<unsigned int>(shift));
 	}
 	else if ( shift == 0 )
 	{
@@ -952,7 +974,7 @@ void LineParser::EvalShiftLeft()
 	}
 	else
 	{
-		result = val >> (-shift);
+		result = ArithmeticShiftRight(val, static_cast<unsigned int>(-shift));
 	}
 
 	m_valueStack[ m_valueStackPtr - 2 ] = static_cast< double >( result );
@@ -980,7 +1002,7 @@ void LineParser::EvalShiftRight()
 	}
 	else if ( shift > 0 )
 	{
-		result = val >> shift;
+		result = ArithmeticShiftRight(val, static_cast<unsigned int>(shift));
 	}
 	else if ( shift == 0 )
 	{
@@ -988,7 +1010,7 @@ void LineParser::EvalShiftRight()
 	}
 	else
 	{
-		result = val << (-shift);
+		result = LogicalShiftLeft(val, static_cast<unsigned int>(-shift));
 	}
 
 	m_valueStack[ m_valueStackPtr - 2 ] = static_cast< double >( result );

--- a/src/lineparser.cpp
+++ b/src/lineparser.cpp
@@ -371,7 +371,7 @@ void LineParser::SkipStatement()
 /*************************************************************************************************/
 void LineParser::SkipExpression( int bracketCount, bool bAllowOneMismatchedCloseBracket )
 {
-	while ( AdvanceAndCheckEndOfSubStatement() )
+	while ( AdvanceAndCheckEndOfSubStatement(bracketCount == 0) )
 	{
 		if ( bAllowOneMismatchedCloseBracket )
 		{
@@ -514,9 +514,16 @@ bool LineParser::AdvanceAndCheckEndOfStatement()
 	@return		bool		true if we are not yet at the end of the substatement
 */
 /*************************************************************************************************/
-bool LineParser::AdvanceAndCheckEndOfSubStatement()
+bool LineParser::AdvanceAndCheckEndOfSubStatement(bool includeComma)
 {
-	return MoveToNextAtom( ";:\\,{}" );
+	if (includeComma)
+	{
+		return MoveToNextAtom( ";:\\,{}" );
+	}
+	else
+	{
+		return MoveToNextAtom( ";:\\{}" );
+	}
 }
 
 

--- a/src/lineparser.cpp
+++ b/src/lineparser.cpp
@@ -330,6 +330,8 @@ void LineParser::SkipStatement()
 		{
 			if ( m_column < m_line.length() && m_line[ m_column ] == '\"' && !bInSingleQuotes )
 			{
+				// This handles quoted quotes in strings (like "a""b") because it views
+				// them as two adjacent strings.
 				bInQuotes = !bInQuotes;
 			}
 			else if ( m_column < m_line.length() && m_line[ m_column ] == '\'' )

--- a/src/lineparser.cpp
+++ b/src/lineparser.cpp
@@ -377,20 +377,17 @@ void LineParser::SkipExpression( int bracketCount, bool bAllowOneMismatchedClose
 {
 	while ( AdvanceAndCheckEndOfSubStatement(bracketCount == 0) )
 	{
-		if ( bAllowOneMismatchedCloseBracket )
+		if ( m_line[ m_column ] == '(' )
 		{
-			if ( m_line[ m_column ] == '(' )
-			{
-				bracketCount++;
-			}
-			else if ( m_line[ m_column ] == ')' )
-			{
-				bracketCount--;
+			bracketCount++;
+		}
+		else if ( m_line[ m_column ] == ')' )
+		{
+			bracketCount--;
 
-				if ( bracketCount < 0 )
-				{
-					break;
-				}
+			if (bAllowOneMismatchedCloseBracket && ( bracketCount < 0 ) )
+			{
+				break;
 			}
 		}
 

--- a/src/lineparser.cpp
+++ b/src/lineparser.cpp
@@ -98,8 +98,10 @@ void LineParser::Process()
 					  ( isalpha( m_line[ m_column ] ) ||
 						isdigit( m_line[ m_column ] ) ||
 						m_line[ m_column ] == '_' ||
-						m_line[ m_column ] == '%' ) &&
-						m_line[ m_column - 1 ] != '%' );
+						m_line[ m_column ] == '%' ||
+						m_line[ m_column ] == '$' ) &&
+						m_line[ m_column - 1 ] != '%' &&
+						m_line[ m_column - 1 ] != '$' );
 
 			if ( AdvanceAndCheckEndOfStatement() )
 			{
@@ -550,8 +552,10 @@ string LineParser::GetSymbolName()
 			  ( isalpha( m_line[ m_column ] ) ||
 				isdigit( m_line[ m_column ] ) ||
 				m_line[ m_column ] == '_' ||
-				m_line[ m_column ] == '%' ) &&
-				m_line[ m_column - 1 ] != '%' );
+				m_line[ m_column ] == '%' ||
+				m_line[ m_column ] == '$' ) &&
+				m_line[ m_column - 1 ] != '%' &&
+				m_line[ m_column - 1 ] != '$' );
 
 	return symbolName;
 }

--- a/src/lineparser.cpp
+++ b/src/lineparser.cpp
@@ -176,7 +176,7 @@ void LineParser::Process()
 				m_column++;
 			}
 
-			double value = EvaluateExpression();
+			Value value = EvaluateExpression();
 
 			if ( GlobalData::Instance().IsFirstPass() )
 			{
@@ -227,7 +227,7 @@ void LineParser::Process()
 					{
 						if ( !SymbolTable::Instance().IsSymbolDefined( paramName ) )
 						{
-							double value = EvaluateExpression();
+							Value value = EvaluateExpression();
 							SymbolTable::Instance().AddSymbol( paramName, value );
 						}
 						else if ( GlobalData::Instance().IsSecondPass() )
@@ -238,7 +238,7 @@ void LineParser::Process()
 							// macro parameter rather than the new value of the outer macro
 							// parameter. See local-forward-branch-5.6502 for an example.
 							SymbolTable::Instance().RemoveSymbol( paramName );
-							double value = EvaluateExpression();
+							Value value = EvaluateExpression();
 							SymbolTable::Instance().AddSymbol( paramName, value );
 						}
 					}

--- a/src/lineparser.h
+++ b/src/lineparser.h
@@ -91,6 +91,7 @@ private:
 	{
 		const char*			token;
 		int					precedence;
+		int					parameterCount;
 		OperatorHandler		handler;
 	};
 
@@ -110,7 +111,7 @@ private:
 	bool			MoveToNextAtom( const char* pTerminators = NULL );
 	bool			AdvanceAndCheckEndOfLine();
 	bool			AdvanceAndCheckEndOfStatement();
-	bool			AdvanceAndCheckEndOfSubStatement();
+	bool			AdvanceAndCheckEndOfSubStatement(bool includeComma);
 	void			SkipStatement();
 	void			SkipExpression( int bracketCount, bool bAllowOneMismatchedCloseBracket );
 	std::string		GetSymbolName();
@@ -220,6 +221,11 @@ private:
 	void			EvalTime();
 	void			EvalStr();
 	void			EvalVal();
+	void			EvalLen();
+	void			EvalChr();
+	void			EvalAsc();
+	void			EvalMid();
+	void			EvalString();
 
 	Value			FormatAssemblyTime(const char* formatString);
 

--- a/src/lineparser.h
+++ b/src/lineparser.h
@@ -172,6 +172,7 @@ private:
 
 	// convenience functions for getting operator parameters from the stack
 	std::pair<Value, Value> StackTopTwoValues();
+	String LineParser::StackTopString();
 	double LineParser::StackTopNumber();
 	std::pair<double, double> StackTopTwoNumbers();
 	std::pair<int, int> StackTopTwoInts();
@@ -217,6 +218,8 @@ private:
 	void			EvalLn();
 	void			EvalExp();
 	void			EvalTime();
+	void			EvalStr();
+	void			EvalVal();
 
 	Value			FormatAssemblyTime(const char* formatString);
 

--- a/src/lineparser.h
+++ b/src/lineparser.h
@@ -171,6 +171,7 @@ private:
 	double			EvaluateExpressionAsDouble( bool bAllowOneMismatchedCloseBracket = false );
 	int				EvaluateExpressionAsInt( bool bAllowOneMismatchedCloseBracket = false );
 	unsigned int	EvaluateExpressionAsUnsignedInt( bool bAllowOneMismatchedCloseBracket = false );
+	std::string		EvaluateExpressionAsString( bool bAllowOneMismatchedCloseBracket = false );
 	Value			GetValue();
 
 	// convenience functions for getting operator parameters from the stack

--- a/src/lineparser.h
+++ b/src/lineparser.h
@@ -24,6 +24,7 @@
 #define LINEPARSER_H_
 
 #include <string>
+#include "value.h"
 
 class SourceCode;
 
@@ -135,7 +136,7 @@ private:
 	void			HandleInclude();
 	void			HandleIncBin();
 	void			HandleEqub();
-	void			HandleEqus(const std::string& equs);
+	void			HandleEqus(const String& equs);
 	void			HandleEquw();
 	void			HandleEqud();
 	void			HandleAssert();
@@ -163,10 +164,17 @@ private:
 
 	// expression evaluating methods
 
-	double			EvaluateExpression( bool bAllowOneMismatchedCloseBracket = false );
+	Value			EvaluateExpression( bool bAllowOneMismatchedCloseBracket = false );
+	double			EvaluateExpressionAsDouble( bool bAllowOneMismatchedCloseBracket = false );
 	int				EvaluateExpressionAsInt( bool bAllowOneMismatchedCloseBracket = false );
 	unsigned int	EvaluateExpressionAsUnsignedInt( bool bAllowOneMismatchedCloseBracket = false );
-	double			GetValue();
+	Value			GetValue();
+
+	// convenience functions for getting operator parameters from the stack
+	std::pair<Value, Value> StackTopTwoValues();
+	double LineParser::StackTopNumber();
+	std::pair<double, double> StackTopTwoNumbers();
+	std::pair<int, int> StackTopTwoInts();
 
 	void			EvalAdd();
 	void			EvalSubtract();
@@ -208,7 +216,9 @@ private:
 	void			EvalLog();
 	void			EvalLn();
 	void			EvalExp();
+	void			EvalTime();
 
+	Value			FormatAssemblyTime(const char* formatString);
 
 	SourceCode*				m_sourceCode;
 	std::string				m_line;
@@ -222,7 +232,7 @@ private:
 	#define MAX_VALUES		128
 	#define MAX_OPERATORS	32
 
-	double					m_valueStack[ MAX_VALUES ];
+	Value					m_valueStack[ MAX_VALUES ];
 	Operator				m_operatorStack[ MAX_OPERATORS ];
 	int						m_valueStackPtr;
 	int						m_operatorStackPtr;

--- a/src/lineparser.h
+++ b/src/lineparser.h
@@ -230,6 +230,8 @@ private:
 	void			EvalChr();
 	void			EvalAsc();
 	void			EvalMid();
+	void			EvalLeft();
+	void			EvalRight();
 	void			EvalString();
 	void			EvalUpper();
 	void			EvalLower();

--- a/src/lineparser.h
+++ b/src/lineparser.h
@@ -222,6 +222,7 @@ private:
 	void			EvalExp();
 	void			EvalTime();
 	void			EvalStr();
+	void			EvalStrHex();
 	void			EvalVal();
 	void			EvalEval();
 	void			EvalLen();

--- a/src/lineparser.h
+++ b/src/lineparser.h
@@ -173,8 +173,8 @@ private:
 
 	// convenience functions for getting operator parameters from the stack
 	std::pair<Value, Value> StackTopTwoValues();
-	String LineParser::StackTopString();
-	double LineParser::StackTopNumber();
+	String StackTopString();
+	double StackTopNumber();
 	std::pair<double, double> StackTopTwoNumbers();
 	std::pair<int, int> StackTopTwoInts();
 

--- a/src/lineparser.h
+++ b/src/lineparser.h
@@ -223,11 +223,14 @@ private:
 	void			EvalTime();
 	void			EvalStr();
 	void			EvalVal();
+	void			EvalEval();
 	void			EvalLen();
 	void			EvalChr();
 	void			EvalAsc();
 	void			EvalMid();
 	void			EvalString();
+	void			EvalUpper();
+	void			EvalLower();
 
 	Value			FormatAssemblyTime(const char* formatString);
 

--- a/src/lineparser.h
+++ b/src/lineparser.h
@@ -107,6 +107,7 @@ private:
 	int				GetTokenAndAdvanceColumn();
 	void			HandleToken( int i, int oldColumn );
 	int				GetInstructionAndAdvanceColumn();
+	int				GetInstructionExact(const char* instr);
 	int				CheckMacroMatches();
 	bool			MoveToNextAtom( const char* pTerminators = NULL );
 	bool			AdvanceAndCheckEndOfLine();
@@ -162,6 +163,7 @@ private:
 	void			HandleError();
 	void			HandleCopyBlock();
 	void			HandleRandomize();
+	void			HandleAsm();
 
 	// expression evaluating methods
 

--- a/src/lineparser.h
+++ b/src/lineparser.h
@@ -107,7 +107,7 @@ private:
 	int				GetTokenAndAdvanceColumn();
 	void			HandleToken( int i, int oldColumn );
 	int				GetInstructionAndAdvanceColumn();
-	int				GetInstructionExact(const char* instr);
+	int				GetInstructionAndAdvanceColumn(bool requireDistinctOpcodes);
 	int				CheckMacroMatches();
 	bool			MoveToNextAtom( const char* pTerminators = NULL );
 	bool			AdvanceAndCheckEndOfLine();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -76,6 +76,7 @@ int main( int argc, char* argv[] )
 		WAITING_FOR_DISC_TITLE,
 		WAITING_FOR_DISC_WRITES,
 		WAITING_FOR_SYMBOL,
+		WAITING_FOR_STRING_SYMBOL,
 		WAITING_FOR_LABELS_FILE
 
 	} state = READY;
@@ -154,6 +155,10 @@ int main( int argc, char* argv[] )
 				{
 					state = WAITING_FOR_SYMBOL;
 				}
+				else if ( strcmp( argv[i], "-S" ) == 0 )
+				{
+					state = WAITING_FOR_STRING_SYMBOL;
+				}
 				else if ( ( strcmp( argv[i], "--help" ) == 0 ) ||
 					  ( strcmp( argv[i], "-help" ) == 0 ) ||
 					  ( strcmp( argv[i], "-h" ) == 0 ) )
@@ -174,7 +179,8 @@ int main( int argc, char* argv[] )
 					cout << " -dd            Dump all global and local symbols after assembly" << endl;
 					cout << " -w             Require whitespace between opcodes and labels" << endl;
 					cout << " -vc            Use Visual C++-style error messages" << endl;
-					cout << " -D <sym>=<val> Define symbol prior to assembly" << endl;
+					cout << " -D <sym>=<val> Define numeric symbol prior to assembly" << endl;
+					cout << " -S <sym>=<str> Define string symbol prior to assembly" << endl;
 					cout << " --help         See this help again" << endl;
 					return EXIT_SUCCESS;
 				}
@@ -251,6 +257,16 @@ int main( int argc, char* argv[] )
 				if ( ! SymbolTable::Instance().AddCommandLineSymbol( argv[i] ) )
 				{
 					cerr << "Invalid -D expression: " << argv[i] << endl;
+					return EXIT_FAILURE;
+				}
+				state = READY;
+				break;
+
+			case WAITING_FOR_STRING_SYMBOL:
+
+				if ( ! SymbolTable::Instance().AddCommandLineStringSymbol( argv[i] ) )
+				{
+					cerr << "Invalid -S expression: " << argv[i] << endl;
 					return EXIT_FAILURE;
 				}
 				state = READY;

--- a/src/symboltable.cpp
+++ b/src/symboltable.cpp
@@ -265,6 +265,42 @@ bool SymbolTable::AddCommandLineSymbol( const std::string& expr )
 
 /*************************************************************************************************/
 /**
+	SymbolTable::AddCommandLineStringSymbol()
+
+	Adds a string symbol to the symbol table using a command line 'FOO=BAR' expression
+
+	@param		expr			Symbol name and value
+	@returns	bool
+*/
+/*************************************************************************************************/
+bool SymbolTable::AddCommandLineStringSymbol( const std::string& expr )
+{
+	std::string::size_type equalsIndex = expr.find( '=' );
+	std::string symbol;
+	std::string valueString;
+	if ( equalsIndex == std::string::npos )
+	{
+		return false;
+	}
+
+	symbol = expr.substr( 0, equalsIndex );
+	valueString = expr.substr( equalsIndex + 1 );
+
+	if ( symbol.empty() )
+	{
+		return false;
+	}
+
+	String value = String(valueString.data(), valueString.length());
+
+	m_map.insert( make_pair( symbol, Symbol( value, false ) ) );
+
+	return true;
+}
+
+
+/*************************************************************************************************/
+/**
 	SymbolTable::GetSymbol()
 
 	Gets the value of a symbol which already exists in the symbol table

--- a/src/symboltable.cpp
+++ b/src/symboltable.cpp
@@ -128,10 +128,10 @@ bool SymbolTable::IsSymbolDefined( const std::string& symbol ) const
 	Adds a symbol to the symbol table with the supplied value
 
 	@param		symbol			The symbol to add
-	@param		int				Its value
+	@param		value			Its value
 */
 /*************************************************************************************************/
-void SymbolTable::AddSymbol( const std::string& symbol, double value, bool isLabel )
+void SymbolTable::AddSymbol( const std::string& symbol, Value value, bool isLabel )
 {
 	assert( !IsSymbolDefined( symbol ) );
 	m_map.insert( make_pair( symbol, Symbol( value, isLabel ) ) );
@@ -272,7 +272,7 @@ bool SymbolTable::AddCommandLineSymbol( const std::string& expr )
 	@param		symbol			The name of the symbol to look for
 */
 /*************************************************************************************************/
-double SymbolTable::GetSymbol( const std::string& symbol ) const
+Value SymbolTable::GetSymbol( const std::string& symbol ) const
 {
 	assert( IsSymbolDefined( symbol ) );
 	return m_map.find( symbol )->second.GetValue();
@@ -341,14 +341,19 @@ void SymbolTable::Dump(bool global, bool all, const char * labels_file) const
 			if ( symbol.IsLabel() &&
 				 symbolName.find_first_of( '@' ) == string::npos )
 			{
-				if ( !bFirst )
+				// This doesn't output string valued symbols
+				Value value = symbol.GetValue();
+				if (value.GetType() == Value::NumberValue)
 				{
-					our_cout << ",";
+					if ( !bFirst )
+					{
+						our_cout << ",";
+					}
+
+					our_cout << "'" << symbolName << "':" << value.GetNumber() << "L";
+
+					bFirst = false;
 				}
-
-				our_cout << "'" << symbolName << "':" << symbol.GetValue() << "L";
-
-				bFirst = false;
 			}
 		}
 	}

--- a/src/symboltable.h
+++ b/src/symboltable.h
@@ -41,6 +41,7 @@ public:
 
 	void AddSymbol( const std::string& symbol, Value value, bool isLabel = false );
 	bool AddCommandLineSymbol( const std::string& expr );
+	bool AddCommandLineStringSymbol( const std::string& expr );
 	void ChangeSymbol( const std::string& symbol, double value );
 	Value GetSymbol( const std::string& symbol ) const;
 	bool IsSymbolDefined( const std::string& symbol ) const;

--- a/src/symboltable.h
+++ b/src/symboltable.h
@@ -29,6 +29,7 @@
 #include <string>
 #include <vector>
 
+#include "value.h"
 
 class SymbolTable
 {
@@ -38,10 +39,10 @@ public:
 	static void Destroy();
 	static inline SymbolTable& Instance() { assert( m_gInstance != NULL ); return *m_gInstance; }
 
-	void AddSymbol( const std::string& symbol, double value, bool isLabel = false );
+	void AddSymbol( const std::string& symbol, Value value, bool isLabel = false );
 	bool AddCommandLineSymbol( const std::string& expr );
 	void ChangeSymbol( const std::string& symbol, double value );
-	double GetSymbol( const std::string& symbol ) const;
+	Value GetSymbol( const std::string& symbol ) const;
 	bool IsSymbolDefined( const std::string& symbol ) const;
 	void RemoveSymbol( const std::string& symbol );
 
@@ -58,15 +59,15 @@ private:
 	{
 	public:
 
-		Symbol( double value, bool isLabel ) : m_value( value ), m_isLabel( isLabel ) {}
+		Symbol( Value value, bool isLabel ) : m_value( value ), m_isLabel( isLabel ) {}
 
-		void SetValue( double d ) { m_value = d; }
-		double GetValue() const { return m_value; }
+		void SetValue( Value value ) { m_value = value; }
+		Value GetValue() const { return m_value; }
 		bool IsLabel() const { return m_isLabel; }
 
 	private:
 
-		double	m_value;
+		Value	m_value;
 		bool	m_isLabel;
 	};
 

--- a/src/value.h
+++ b/src/value.h
@@ -87,6 +87,38 @@ public:
 		buffer[length] = 0;
 		return header;
 	}
+
+	static StringHeader* SubString(StringHeader* source, unsigned int index, unsigned int length)
+	{
+		assert(index <= Length(source));
+		unsigned int realLength = std::min(length, Length(source) - index);
+		if ((index == 0) && (realLength == Length(source)))
+		{
+			return source;
+		}
+		return Allocate(StringData(source) + index, realLength);
+	}
+
+	static StringHeader* Repeat(StringHeader* source, unsigned int count)
+	{
+		int sourceLength = Length(source);
+		const char* sourceData = StringData(source);
+
+		assert((sourceLength < 0x10000) && (count < 0x10000));
+		unsigned int length = sourceLength * count;
+		assert(length < 0x10000);
+
+		StringHeader* header = Allocate(length);
+		char* buffer = StringBuffer(header);
+		for (unsigned int i = 0; i != count; ++i)
+		{
+			memcpy(buffer, sourceData, sourceLength);
+			buffer += sourceLength;
+		}
+		*buffer = 0;
+		return header;
+	}
+
 private:
 	static char* StringBuffer(StringHeader* header)
 	{
@@ -146,6 +178,16 @@ public:
 	String operator+(const String& that)
 	{
 		StringHeader* header = StringHeader::Concat(m_header, that.m_header);
+		return String(header);
+	}
+	String SubString(unsigned int index, unsigned int length)
+	{
+		StringHeader* header = StringHeader::SubString(m_header, index, length);
+		return String(header);
+	}
+	String Repeat(unsigned int count)
+	{
+		StringHeader* header = StringHeader::Repeat(m_header, count);
 		return String(header);
 	}
 	unsigned int Length() const

--- a/src/value.h
+++ b/src/value.h
@@ -1,0 +1,315 @@
+/*************************************************************************************************/
+/**
+	value.h
+
+
+	Copyright (C) Charles Reilly 2021
+
+	This file is part of BeebAsm.
+
+	BeebAsm is free software: you can redistribute it and/or modify it under the terms of the GNU
+	General Public License as published by the Free Software Foundation, either version 3 of the
+	License, or (at your option) any later version.
+
+	BeebAsm is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+	even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License along with BeebAsm, as
+	COPYING.txt.  If not, see <http://www.gnu.org/licenses/>.
+*/
+/*************************************************************************************************/
+
+#ifndef VALUE_H_
+#define VALUE_H_
+
+#include <cassert>
+
+// A simple immutable string buffer with a length and a reference count.
+// This doesn't have constructors, etc. so it can be stuffed into a union.
+struct StringHeader
+{
+private:
+	unsigned int m_refCount;
+	unsigned int m_length;
+
+public:
+	static StringHeader* Allocate(const char* text, unsigned int length)
+	{
+		StringHeader* header = Allocate(length);
+		char* buffer = StringBuffer(header);
+		memcpy(buffer, text, length);
+		buffer[length] = 0;
+		return header;
+	}
+
+	static const char* StringData(StringHeader* header)
+	{
+		return StringBuffer(header);
+	}
+
+	static void AddRef(StringHeader* header)
+	{
+		header->m_refCount++;
+	}
+
+	static void Release(StringHeader** ppheader)
+	{
+		StringHeader*& header = *ppheader;
+		header->m_refCount--;
+		if (header->m_refCount == 0)
+		{
+			free(header);
+		}
+		header = 0;
+	}
+
+	static unsigned int Length(StringHeader* header)
+	{
+		return header->m_length;
+	}
+
+	static int Compare(StringHeader* header1, StringHeader* header2)
+	{
+		int result = memcmp(StringData(header1), StringData(header2), std::min(header1->m_length, header2->m_length));
+		if (result != 0)
+			return result;
+		return Compare(header1->m_length, header2->m_length);
+	}
+
+	static StringHeader* Concat(StringHeader* header1, StringHeader* header2)
+	{
+		int length = header1->m_length + header2->m_length;
+		StringHeader* header = Allocate(length);
+		char* buffer = StringBuffer(header);
+		memcpy(buffer, StringData(header1), header1->m_length);
+		memcpy(buffer + header1->m_length, StringData(header2), header2->m_length);
+		buffer[length] = 0;
+		return header;
+	}
+private:
+	static char* StringBuffer(StringHeader* header)
+	{
+		return reinterpret_cast<char*>(header) + sizeof(StringHeader);
+	}
+
+	static StringHeader* Allocate(unsigned int length)
+	{
+		int fullLength = sizeof(StringHeader) + length + 1;
+		StringHeader* header = static_cast<StringHeader*>(malloc(fullLength));
+		if (!header)
+			return 0;
+		header->m_refCount = 0;
+		header->m_length = length;
+		return header;
+	}
+
+	static int Compare(unsigned int a, unsigned int b)
+	{
+		if (a == b)
+			return 0;
+		else if (a < b)
+			return -1;
+		else
+			return 1;
+	}
+};
+
+// A simple immutable string.
+class String
+{
+public:
+	~String()
+	{
+		StringHeader::Release(&m_header);
+	}
+	String(const String& that)
+	{
+		m_header = that.m_header;
+		StringHeader::AddRef(m_header);
+	}
+	String(const char* text, unsigned int length)
+	{
+		m_header = StringHeader::Allocate(text, length);
+		StringHeader::AddRef(m_header);
+	}
+	String& operator=(const String& that)
+	{
+		if (m_header != that.m_header)
+		{
+			StringHeader::Release(&m_header);
+			m_header = that.m_header;
+			StringHeader::AddRef(m_header);
+		}
+		return *this;
+	}
+	String operator+(const String& that)
+	{
+		StringHeader* header = StringHeader::Concat(m_header, that.m_header);
+		return String(header);
+	}
+	unsigned int Length() const
+	{
+		return StringHeader::Length(m_header);
+	}
+	const char* Text() const
+	{
+		return StringHeader::StringData(m_header);
+	}
+	char operator[](int index) const
+	{
+		assert((0 <= index) && (static_cast<unsigned int>(index) < Length()));
+		return Text()[index];
+	}
+private:
+	friend class Value;
+	StringHeader* m_header;
+
+	String(StringHeader* header)
+	{
+		m_header = header;
+		StringHeader::AddRef(m_header);
+	}
+};
+
+// A value that can be a string or a number
+class Value
+{
+public:
+	enum Type
+	{
+		NumberValue,
+		StringValue
+	};
+
+	Value()
+	{
+		m_type = NumberValue;
+		m_number = 0;
+	}
+
+	Value(double number)
+	{
+		m_type = NumberValue;
+		m_number = number;
+	}
+
+	Value(String s)
+	{
+		m_type = StringValue;
+		m_string = s.m_header;
+		StringHeader::AddRef(m_string);
+	}
+
+	Value(const Value& that)
+	{
+		Assign(that);
+	}
+
+	Value& operator=(const Value& that)
+	{
+		if ((m_type != StringValue) || (that.m_type != StringValue) || (m_string != that.m_string))
+		{
+			Clear();
+			Assign(that);
+		}
+		return *this;
+	}
+
+	~Value()
+	{
+		Clear();
+	}
+
+	Type GetType() const
+	{
+		return m_type;
+	}
+
+	double GetNumber() const
+	{
+		assert(m_type == NumberValue);
+		return m_number;
+	}
+
+	String GetString() const
+	{
+		assert(m_type == StringValue);
+		return String(m_string);
+	}
+
+	static int Compare(Value value1, Value value2)
+	{
+		if (value1.GetType() == value2.GetType())
+		{
+			if (value1.GetType() == NumberValue)
+			{
+				return Compare(value1.GetNumber(), value2.GetNumber());
+			}
+			else if (value1.GetType() == StringValue)
+			{
+				return StringHeader::Compare(value1.m_string, value2.m_string);
+			}
+			else
+			{
+				assert(false);
+			}
+			return 0;
+		}
+		if (value1.GetType() < value2.GetType())
+		{
+			return -1;
+		}
+		else
+		{
+			return 1;
+		}
+	}
+
+private:
+	union
+	{
+		double m_number;
+		StringHeader* m_string;
+	};
+
+	Type m_type;
+
+	void Clear()
+	{
+		if ((m_type == StringValue) && m_string)
+		{
+			StringHeader::Release(&m_string);
+		}
+	}
+
+	void Assign(const Value& that)
+	{
+		m_type = that.m_type;
+		if (m_type == NumberValue)
+		{
+			m_number = that.m_number;
+		}
+		else if (m_type == StringValue)
+		{
+			m_string = that.m_string;
+			StringHeader::AddRef(m_string);
+		}
+		else
+		{
+			assert(false);
+		}
+	}
+
+	static int Compare(double a, double b)
+	{
+		if (a == b)
+			return 0;
+		else if (a < b)
+			return -1;
+		else
+			return 1;
+	}
+};
+
+#endif // VALUE_H_

--- a/src/value.h
+++ b/src/value.h
@@ -24,6 +24,7 @@
 #define VALUE_H_
 
 #include <cassert>
+#include <cstring>
 
 // A simple immutable string buffer with a length and a reference count.
 // This doesn't have constructors, etc. so it can be stuffed into a union.

--- a/src/value.h
+++ b/src/value.h
@@ -24,7 +24,7 @@
 #define VALUE_H_
 
 #include <cassert>
-#include <cstring>
+#include <string.h>
 
 // A simple immutable string buffer with a length and a reference count.
 // This doesn't have constructors, etc. so it can be stuffed into a union.


### PR DESCRIPTION
The README has the new functions.

There's still no way of using a string as an assembler mnemonic or an addressing mode, which I know some people would like.  This could be handled with an ASSEMBLE command which takes two strings (the mnemonic and the parameters) and assembles them.  Anyway, that's something that could be built on this.

This is quite a big change so comments are very welcome.
