### PR TITLE
Fix ASSERT directive to work correctly

### DIFF
--- a/examples/assertdemo.6502
+++ b/examples/assertdemo.6502
@@ -1,13 +1,15 @@
 org &2000
 
 .start
-	assert (addr_offset + 3) <= 255
+	assert TRUE
+	assert 65==65
 
 	\ You can assert multiple things if you wish: 
-	assert 65==65, loop == start + 4
-	assert 1+2==3, 2+2 == 5
-
-	assert start == &2000
+	assert start == &2000, loop == start + 4
+	assert 1+2==3, 2+2 == 5 \ The second expression is clearly false and
+	                        \ compilation will fail with an error message
+                            \ showing the line and identifying the second
+                            \ expression as failing.
 
 	ldy #addr_offset
 	ldx #0

--- a/examples/assertdemo.6502
+++ b/examples/assertdemo.6502
@@ -1,15 +1,18 @@
 org &2000
 
 .start
+	assert 1
 	assert TRUE
+	assert -1 \ BBC Basic defines TRUE to be -1
 	assert 65==65
 
 	\ You can assert multiple things if you wish: 
 	assert start == &2000, loop == start + 4
-	assert 1+2==3, 2+2 == 5 \ The second expression is clearly false and
-	                        \ compilation will fail with an error message
-                            \ showing the line and identifying the second
-                            \ expression as failing.
+
+	\ The second expression below is clearly false and compilation will fail
+	\ with an error message showing the line and identifying the second
+	\ expression as failing.
+	assert 1+2==3, 2+2 == 5
 
 	ldy #addr_offset
 	ldx #0

--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -1081,18 +1081,18 @@ void LineParser::HandleAssert()
 {
 	do
 	{
-		unsigned int value;
+		int value;
 
 		try
 		{
 			// Take a copy of the column before evaluating the expression so
 			// we can point correctly at the failed expression when throwing.
 			size_t column = m_column;
-			value = EvaluateExpressionAsUnsignedInt();
+			value = EvaluateExpressionAsInt();
 			// We never throw for value being false on the first pass, simply
 			// to ensure that if two assertions both fail, the one which 
 			// appears earliest in the source will be reported.
-			if ( !GlobalData::Instance().IsFirstPass() && !value )
+			if ( !GlobalData::Instance().IsFirstPass() && (value != -1) )
 			{
 				while ( ( column < m_line.length() ) && isspace( static_cast< unsigned char >( m_line[ column ] ) ) )
 				{

--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -1092,7 +1092,7 @@ void LineParser::HandleAssert()
 			// We never throw for value being false on the first pass, simply
 			// to ensure that if two assertions both fail, the one which 
 			// appears earliest in the source will be reported.
-			if ( !GlobalData::Instance().IsFirstPass() && (value != -1) )
+			if ( !GlobalData::Instance().IsFirstPass() && !value )
 			{
 				while ( ( column < m_line.length() ) && isspace( static_cast< unsigned char >( m_line[ column ] ) ) )
 				{


### PR DESCRIPTION
Also cleaned up assertdemo.6502.

I have only been able to test this fix on Mac OS X OS 12.2 with toolchain `Apple clang version 12.0.5 (clang-1205.0.22.9) Target: arm64-apple-darwin21.3.0`. Since this bug is caused by undefined behavior I'd appreciate if others could test the PR on Windows and MSVC.