### PR TITLE
Use ARM intrinsic for compatible flt-to-int

### DIFF
--- a/src/lineparser.h
+++ b/src/lineparser.h
@@ -238,6 +238,8 @@ private:
 
 	Value			FormatAssemblyTime(const char* formatString);
 
+	int				CastDblToInt(double d);
+	
 	SourceCode*				m_sourceCode;
 	std::string				m_line;
 	size_t					m_column;


### PR DESCRIPTION
For int conversion of floating point values larger than can fit in an
int, ARM handles the situation differently from x86. This difference
causes test failures. On supported ARM platforms we use an intrinsic to
access the specific ARM instruction that produces the same handling as
x86.