### PR TITLE
Add -writes option to set number of disc writes in ssd catalogue

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,10 @@ If specifed, BeebAsm will create a !Boot file on the new disc image, containing 
 
 If specified, this sets the disc option of the generated disc image (i.e. the `*OPT 4,n` value) to the value specified.  This overrides the -boot option.
 
+`-writes <value>`
+
+If specified, this sets the write count of the generated disc image (i.e. the value show in brackets after the disc title in a catalogue) to the value specified.  This defaults to 0 if not specified.
+
 `-title <title>`
 
 If specified, this sets the disc title of the generated disc image (i.e. the string set by `*TITLE`) to the value specified.
@@ -693,6 +697,8 @@ There is also a demo called `"relocdemo.asm"`, which shows how the 'reload addre
 
 ## 9. VERSION HISTORY
 ```
+??/??/????  1.10?
+                  Added command line option: -writes
 12/05/2018  1.09  Added ASSERT
                   Added CPU (as a constant)
                   Added PUTTEXT

--- a/src/discimage.cpp
+++ b/src/discimage.cpp
@@ -112,6 +112,7 @@ DiscImage::DiscImage( const char* pOutput, const char* pInput )
 		// generate a blank catalog
 
 		memset( m_aCatalog, 0, 0x200 );
+		m_aCatalog[ 0x104 ] = GlobalData::Instance().GetDiscWrites();
 		m_aCatalog[ 0x106 ] = 0x03 | ( ( GlobalData::Instance().GetDiscOption() & 3 ) << 4);
 		m_aCatalog[ 0x107 ] = 0x20;
 

--- a/src/globaldata.cpp
+++ b/src/globaldata.cpp
@@ -76,6 +76,7 @@ GlobalData::GlobalData()
 		m_pOutputFile( NULL ),
 		m_numAnonSaves( 0 ),
 		m_discOption( 0 ),
+		m_discWrites( -1 ),
 		m_assemblyTime( time( NULL ) ),
 		m_bRequireDistinctOpcodes( false ),
 		m_bUseVisualCppErrorFormat( false )

--- a/src/globaldata.cpp
+++ b/src/globaldata.cpp
@@ -76,7 +76,7 @@ GlobalData::GlobalData()
 		m_pOutputFile( NULL ),
 		m_numAnonSaves( 0 ),
 		m_discOption( 0 ),
-		m_discWrites( -1 ),
+		m_discWrites( 0 ),
 		m_assemblyTime( time( NULL ) ),
 		m_bRequireDistinctOpcodes( false ),
 		m_bUseVisualCppErrorFormat( false )

--- a/src/globaldata.h
+++ b/src/globaldata.h
@@ -49,6 +49,7 @@ public:
 	inline void SetOutputFile( const char* p )	{ m_pOutputFile = p; }
 	inline void IncNumAnonSaves()				{ m_numAnonSaves++; }
 	inline void SetDiscOption( int opt )		{ m_discOption = opt; }
+	inline void SetDiscWrites( int num )		{ m_discWrites = num; }
 	inline void SetDiscTitle( const std::string& t )  
 												{ m_discTitle = t; }
 	inline void SetRequireDistinctOpcodes ( bool b )
@@ -68,6 +69,7 @@ public:
 	inline const char* GetOutputFile() const	{ return m_pOutputFile; }
 	inline int GetNumAnonSaves() const			{ return m_numAnonSaves; }
 	inline int GetDiscOption() const			{ return m_discOption; }
+	inline int GetDiscWrites() const			{ return m_discWrites; }
 	inline const std::string& GetDiscTitle() const
 												{ return m_discTitle; }
 	inline time_t GetAssemblyTime() const		{ return m_assemblyTime; }
@@ -91,6 +93,7 @@ private:
 	const char*					m_pOutputFile;
 	int							m_numAnonSaves;
 	int							m_discOption;
+	int							m_discWrites;
 	std::string					m_discTitle;
 	time_t						m_assemblyTime;
 	bool						m_bRequireDistinctOpcodes;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -73,6 +73,7 @@ int main( int argc, char* argv[] )
 		WAITING_FOR_BOOT_FILENAME,
 		WAITING_FOR_DISC_OPTION,
 		WAITING_FOR_DISC_TITLE,
+		WAITING_FOR_DISC_WRITES,
 		WAITING_FOR_SYMBOL
 
 	} state = READY;
@@ -117,6 +118,10 @@ int main( int argc, char* argv[] )
 				else if ( strcmp( argv[i], "-title" ) == 0 )
 				{
 					state = WAITING_FOR_DISC_TITLE;
+				}
+				else if ( strcmp( argv[i], "-writes" ) == 0 )
+				{
+					state = WAITING_FOR_DISC_WRITES;
 				}
 				else if ( strcmp( argv[i], "-w" ) == 0 )
 				{
@@ -218,6 +223,12 @@ int main( int argc, char* argv[] )
 				GlobalData::Instance().SetDiscTitle( argv[i] );
 				state = READY;
                                 break;
+
+			case WAITING_FOR_DISC_WRITES:
+
+				GlobalData::Instance().SetDiscWrites( std::strtol( argv[i], NULL, 10 ) );
+				state = READY;
+				break;
 
 			case WAITING_FOR_SYMBOL:
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -153,6 +153,7 @@ int main( int argc, char* argv[] )
 					cout << " -do <file>     Specify a disc image file to output" << endl;
 					cout << " -boot <file>   Specify a filename to be run by !BOOT on a new disc image" << endl;
 					cout << " -opt <opt>     Specify the *OPT 4,n for the generated disc image" << endl;
+					cout << " -writes <n>    Specify the write count for the generated disc image" << endl;
 					cout << " -title <title> Specify the title for the generated disc image" << endl;
 					cout << " -v             Verbose output" << endl;
 					cout << " -d             Dump all global symbols after assembly" << endl;


### PR DESCRIPTION
As discussed in https://github.com/stardot/beebasm/issues/39. Do we need to tweak the validation before merging?

(github shows this can't be automatically merged, although I suspect it's not a difficult issue to resolve.)