### PR TITLE
Suppress unsaved warning if no memory used.  Fixes #78.

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -42,7 +42,7 @@
 using namespace std;
 
 
-#define VERSION "1.10-pre"
+#define VERSION "1.10rc2"
 
 
 /*************************************************************************************************/
@@ -350,7 +350,7 @@ int main( int argc, char* argv[] )
 		SymbolTable::Instance().Dump(bDumpSymbols, bDumpAllSymbols, pLabelsOutputFile);
 	}
 
-	if ( !GlobalData::Instance().IsSaved() && exitCode == EXIT_SUCCESS )
+	if ( !GlobalData::Instance().IsSaved() && ObjectCode::Instance().AnyUsed() && exitCode == EXIT_SUCCESS )
 	{
 		cerr << "warning: no SAVE command in source file." << endl;
 	}

--- a/src/objectcode.cpp
+++ b/src/objectcode.cpp
@@ -491,3 +491,23 @@ void ObjectCode::CopyBlock( int start, int end, int dest, bool firstPass )
 		}
 	}
 }
+
+#define ARRAY_LENGTH(a) (sizeof(a) / sizeof(a[0]))
+
+/*************************************************************************************************/
+/**
+	ObjectCode::AnyUsed() - is any memory USED?
+*/
+/*************************************************************************************************/
+bool ObjectCode::AnyUsed() const
+{
+	for (int i = 0; i < ARRAY_LENGTH(m_aFlags); ++i)
+	{
+		if ( m_aFlags[i] & USED )
+		{
+			return true;
+		}
+	}
+
+	return false;
+}

--- a/src/objectcode.cpp
+++ b/src/objectcode.cpp
@@ -501,7 +501,7 @@ void ObjectCode::CopyBlock( int start, int end, int dest, bool firstPass )
 /*************************************************************************************************/
 bool ObjectCode::AnyUsed() const
 {
-	for (int i = 0; i < ARRAY_LENGTH(m_aFlags); ++i)
+	for (unsigned int i = 0; i < ARRAY_LENGTH(m_aFlags); ++i)
 	{
 		if ( m_aFlags[i] & USED )
 		{

--- a/src/objectcode.h
+++ b/src/objectcode.h
@@ -59,6 +59,8 @@ public:
 
 	void CopyBlock( int start, int end, int dest, bool firstPass );
 
+	bool AnyUsed() const;
+
 private:
 
 	// Each byte in the memory map has a set of flags

--- a/test/3-directives/save/anyused.6502
+++ b/test/3-directives/save/anyused.6502
@@ -1,0 +1,3 @@
+\ Ensure "no save" warning checks up to the end of memory
+ORG &FFFF
+BRK

--- a/test/3-directives/save/anyused.gold.txt
+++ b/test/3-directives/save/anyused.gold.txt
@@ -1,0 +1,1 @@
+warning: no SAVE command in source file.


### PR DESCRIPTION
Also update `beebasm -h` version to v1.10rc2