### PR TITLE
Default and negative -D values broken.  Fixes #83.

### DIFF
--- a/src/literals.cpp
+++ b/src/literals.cpp
@@ -164,10 +164,16 @@ bool Literals::ParseNumeric(const std::string& line, size_t& index, double& resu
 		return false;
 	}
 
-	if ( is_decimal_digit(line[index]) || line[index] == '.' )
+	if ( is_decimal_digit(line[index]) || line[index] == '.' || line[index] == '-' )
 	{
 		// Copy the number without underscores to this buffer
 		std::string buffer;
+
+		if ( line[index] == '-' )
+		{
+			buffer.push_back('-');
+			index++;
+		}
 
 		// Copy digits preceding decimal point
 		bool have_digits = CopyDigitsSkippingUnderscores(line, index, buffer);

--- a/src/symboltable.cpp
+++ b/src/symboltable.cpp
@@ -195,7 +195,10 @@ bool SymbolTable::AddCommandLineSymbol( const std::string& expr )
 	double value;
 	try
 	{
-		Literals::ParseNumeric(valueString, index, value);
+		if ( !Literals::ParseNumeric(valueString, index, value) )
+		{
+			return false;
+		}
 	}
 	catch (AsmException_SyntaxError const&)
 	{

--- a/test/1-values/cmdlinedefinedefault.6502
+++ b/test/1-values/cmdlinedefinedefault.6502
@@ -1,0 +1,3 @@
+\ beebasm -D V
+\ Check default command-line -D value is -1
+assert(V=-1)

--- a/test/1-values/cmdlinedefinemissing.fail.6502
+++ b/test/1-values/cmdlinedefinemissing.fail.6502
@@ -1,0 +1,2 @@
+\ beebasm -D V=
+\ Check handling of missing value defined on the command-line with -D

--- a/test/1-values/cmdlinedefinenegative.6502
+++ b/test/1-values/cmdlinedefinenegative.6502
@@ -1,0 +1,3 @@
+\ beebasm -D V=-1_2.3_4
+\ Check parsing of negative values defined on the command-line with -D
+assert(V=-12.34)


### PR DESCRIPTION
The new number parser that handles underscores didn't handle negative numbers.  This mostly isn't a problem because `-` is treated as a unary operator in expressions.  However, -D numbers on the command line are not expressions so negative numbers stopped working.  The default also broke because this parses the string "-1"!

This is rather a significant bug so this fix ought to go into v1.10.