### PR TITLE
Add DEFINE and ASSIGN directives

### DIFF
--- a/README.md
+++ b/README.md
@@ -643,9 +643,38 @@ Abort assembly if any of the expressions is false.
 
 Seed the random number generator used by the RND() function.  If this is not used, the random number generator is seeded based on the current time and so each build of a program using `RND()` will be different.
 
+
 `ASM <str>`
 
 Assemble the supplied assembly language string.  For example `ASM "LDA #&41"`.
+
+
+`DEFINE <var-name> <expr>`
+
+Evaluates `<var-name>` as the name of a variable to define with value `<expr>`. The `<var-name>` expressison must be a string, for example `DEFINE "addr" &70`. It is not possible to re-assign variables.
+
+This must be used instead of `=` when the variable name needs to be generated dynamically such as from macro arguments, for example:
+
+```
+    MACRO VIA name, base_addr
+      DEFINE name, addr
+      DEFINE name + "_IOR_B", base_addr
+      DEFINE name + "_IOR_A", base_addr + 1
+      DEFINE name + "_DDR_B", base_addr + 2
+      DEFINE name + "_DDR_A", base_addr + 3
+      ; ...
+      ; ...
+    ENDMACRO
+
+    VIA SYSVIA, &FE40
+    VIA USERVIA, &FE60
+```
+
+
+`ASSIGN <var-name> <expr>`
+
+Does the same thing as `DEFINE <var-name> <expr>` except that it can be used to change the value of a variable.
+
 
 ## 7. TIPS AND TRICKS
 

--- a/src/lineparser.h
+++ b/src/lineparser.h
@@ -164,6 +164,9 @@ private:
 	void			HandleCopyBlock();
 	void			HandleRandomize();
 	void			HandleAsm();
+	void			HandleDefineAssignCommon( bool bAllowRedefinition );
+	void			HandleDefine();
+	void			HandleAssign();
 
 	// expression evaluating methods
 

--- a/test/3-directives/assign/define-variable.6502
+++ b/test/3-directives/assign/define-variable.6502
@@ -1,0 +1,23 @@
+\ Assign examples
+
+ASSIGN "v1",27183
+ASSERT v1 = 27183
+
+ASSIGN "v2",v1+1
+ASSERT v2 = 27184
+
+prefix = "v"
+ASSIGN prefix + "3", "A string"
+ASSERT v3 = "A string"
+
+ASSIGN "_a",1
+ASSERT _a = 1
+
+ASSIGN "a_",2
+ASSERT a_ = 2
+
+ASSIGN "a$","str"
+ASSERT a$ = "str"
+
+ASSIGN "a%",3
+ASSERT a% = 3

--- a/test/3-directives/assign/name-contains-bang.fail.6502
+++ b/test/3-directives/assign/name-contains-bang.fail.6502
@@ -1,0 +1,2 @@
+\ Variable name cannot contain general punctuation
+ASSIGN "a!b",13

--- a/test/3-directives/assign/name-contains-bang.fail.gold.txt
+++ b/test/3-directives/assign/name-contains-bang.fail.gold.txt
@@ -1,0 +1,1 @@
+error: Invalid symbol name; must start with a letter

--- a/test/3-directives/assign/name-contains-dollar.fail.6502
+++ b/test/3-directives/assign/name-contains-dollar.fail.6502
@@ -1,0 +1,2 @@
+\ Variable name cannot contain a dollar
+ASSIGN "a$b",13

--- a/test/3-directives/assign/name-contains-dollar.fail.gold.txt
+++ b/test/3-directives/assign/name-contains-dollar.fail.gold.txt
@@ -1,0 +1,1 @@
+error: Invalid symbol name; must start with a letter

--- a/test/3-directives/assign/name-contains-percent.fail.6502
+++ b/test/3-directives/assign/name-contains-percent.fail.6502
@@ -1,0 +1,2 @@
+\ Variable name cannot contain a percent
+ASSIGN "a%b",13

--- a/test/3-directives/assign/name-contains-percent.fail.gold.txt
+++ b/test/3-directives/assign/name-contains-percent.fail.gold.txt
@@ -1,0 +1,1 @@
+error: Invalid symbol name; must start with a letter

--- a/test/3-directives/assign/name-empty.fail.6502
+++ b/test/3-directives/assign/name-empty.fail.6502
@@ -1,0 +1,2 @@
+\ Variable name can't be empty
+ASSIGN "",13

--- a/test/3-directives/assign/name-empty.fail.gold.txt
+++ b/test/3-directives/assign/name-empty.fail.gold.txt
@@ -1,0 +1,1 @@
+error: Invalid symbol name; must start with a letter

--- a/test/3-directives/assign/name-not-string.fail.6502
+++ b/test/3-directives/assign/name-not-string.fail.6502
@@ -1,0 +1,2 @@
+\ Variable name must be a string.
+ASSIGN 1,13

--- a/test/3-directives/assign/name-not-string.fail.gold.txt
+++ b/test/3-directives/assign/name-not-string.fail.gold.txt
@@ -1,0 +1,1 @@
+error: Type mismatch

--- a/test/3-directives/assign/name-starts-with-dollar.fail.6502
+++ b/test/3-directives/assign/name-starts-with-dollar.fail.6502
@@ -1,0 +1,2 @@
+\ Variable name can't start with $
+ASSIGN "$a",13

--- a/test/3-directives/assign/name-starts-with-dollar.fail.gold.txt
+++ b/test/3-directives/assign/name-starts-with-dollar.fail.gold.txt
@@ -1,0 +1,1 @@
+error: Invalid symbol name; must start with a letter

--- a/test/3-directives/assign/name-starts-with-number.fail.6502
+++ b/test/3-directives/assign/name-starts-with-number.fail.6502
@@ -1,0 +1,2 @@
+\ Variable name can't start with a number
+ASSIGN "1a",13

--- a/test/3-directives/assign/name-starts-with-number.fail.gold.txt
+++ b/test/3-directives/assign/name-starts-with-number.fail.gold.txt
@@ -1,0 +1,1 @@
+error: Invalid symbol name; must start with a letter

--- a/test/3-directives/assign/name-starts-with-percent.fail.6502
+++ b/test/3-directives/assign/name-starts-with-percent.fail.6502
@@ -1,0 +1,2 @@
+\ Variable name can't start with %
+ASSIGN "%a",13

--- a/test/3-directives/assign/name-starts-with-percent.fail.gold.txt
+++ b/test/3-directives/assign/name-starts-with-percent.fail.gold.txt
@@ -1,0 +1,1 @@
+error: Invalid symbol name; must start with a letter

--- a/test/3-directives/assign/redefine.6502
+++ b/test/3-directives/assign/redefine.6502
@@ -1,0 +1,4 @@
+\ Can reassign variables
+a = 12
+ASSIGN "a",13
+ASSERT a = 13

--- a/test/3-directives/define/define-variable.6502
+++ b/test/3-directives/define/define-variable.6502
@@ -1,0 +1,23 @@
+\ Define examples
+
+DEFINE "v1",27183
+ASSERT v1 = 27183
+
+DEFINE "v2",v1+1
+ASSERT v2 = 27184
+
+prefix = "v"
+DEFINE prefix + "3", "A string"
+ASSERT v3 = "A string"
+
+DEFINE "_a",1
+ASSERT _a = 1
+
+DEFINE "a_",2
+ASSERT a_ = 2
+
+DEFINE "a$","str"
+ASSERT a$ = "str"
+
+DEFINE "a%",3
+ASSERT a% = 3

--- a/test/3-directives/define/name-contains-bang.fail.6502
+++ b/test/3-directives/define/name-contains-bang.fail.6502
@@ -1,0 +1,2 @@
+\ Variable name cannot contain general punctuation
+DEFINE "a!b",13

--- a/test/3-directives/define/name-contains-bang.fail.gold.txt
+++ b/test/3-directives/define/name-contains-bang.fail.gold.txt
@@ -1,0 +1,1 @@
+error: Invalid symbol name; must start with a letter

--- a/test/3-directives/define/name-contains-dollar.fail.6502
+++ b/test/3-directives/define/name-contains-dollar.fail.6502
@@ -1,0 +1,2 @@
+\ Variable name cannot contain a dollar
+DEFINE "a$b",13

--- a/test/3-directives/define/name-contains-dollar.fail.gold.txt
+++ b/test/3-directives/define/name-contains-dollar.fail.gold.txt
@@ -1,0 +1,1 @@
+error: Invalid symbol name; must start with a letter

--- a/test/3-directives/define/name-contains-percent.fail.6502
+++ b/test/3-directives/define/name-contains-percent.fail.6502
@@ -1,0 +1,2 @@
+\ Variable name cannot contain a percent
+DEFINE "a%b",13

--- a/test/3-directives/define/name-contains-percent.fail.gold.txt
+++ b/test/3-directives/define/name-contains-percent.fail.gold.txt
@@ -1,0 +1,1 @@
+error: Invalid symbol name; must start with a letter

--- a/test/3-directives/define/name-empty.fail.6502
+++ b/test/3-directives/define/name-empty.fail.6502
@@ -1,0 +1,2 @@
+\ Variable name can't be empty
+DEFINE "",13

--- a/test/3-directives/define/name-empty.fail.gold.txt
+++ b/test/3-directives/define/name-empty.fail.gold.txt
@@ -1,0 +1,1 @@
+error: Invalid symbol name; must start with a letter

--- a/test/3-directives/define/name-not-string.fail.6502
+++ b/test/3-directives/define/name-not-string.fail.6502
@@ -1,0 +1,2 @@
+\ Variable name must be a string.
+DEFINE 1,13

--- a/test/3-directives/define/name-not-string.fail.gold.txt
+++ b/test/3-directives/define/name-not-string.fail.gold.txt
@@ -1,0 +1,1 @@
+error: Type mismatch

--- a/test/3-directives/define/name-starts-with-dollar.fail.6502
+++ b/test/3-directives/define/name-starts-with-dollar.fail.6502
@@ -1,0 +1,2 @@
+\ Variable name can't start with $
+DEFINE "$a",13

--- a/test/3-directives/define/name-starts-with-dollar.fail.gold.txt
+++ b/test/3-directives/define/name-starts-with-dollar.fail.gold.txt
@@ -1,0 +1,1 @@
+error: Invalid symbol name; must start with a letter

--- a/test/3-directives/define/name-starts-with-number.fail.6502
+++ b/test/3-directives/define/name-starts-with-number.fail.6502
@@ -1,0 +1,2 @@
+\ Variable name can't start with a number
+DEFINE "1a",13

--- a/test/3-directives/define/name-starts-with-number.fail.gold.txt
+++ b/test/3-directives/define/name-starts-with-number.fail.gold.txt
@@ -1,0 +1,1 @@
+error: Invalid symbol name; must start with a letter

--- a/test/3-directives/define/name-starts-with-percent.fail.6502
+++ b/test/3-directives/define/name-starts-with-percent.fail.6502
@@ -1,0 +1,2 @@
+\ Variable name can't start with %
+DEFINE "%a",13

--- a/test/3-directives/define/name-starts-with-percent.fail.gold.txt
+++ b/test/3-directives/define/name-starts-with-percent.fail.gold.txt
@@ -1,0 +1,1 @@
+error: Invalid symbol name; must start with a letter

--- a/test/3-directives/define/redefine.fail.6502
+++ b/test/3-directives/define/redefine.fail.6502
@@ -1,0 +1,3 @@
+\ Can't redefine variables
+a = 12
+DEFINE "a",13

--- a/test/3-directives/define/redefine.fail.gold.txt
+++ b/test/3-directives/define/redefine.fail.gold.txt
@@ -1,0 +1,1 @@
+error: Symbol already defined

--- a/test/testrunner.py
+++ b/test/testrunner.py
@@ -123,7 +123,7 @@ def run_test(beebasm, path, file_names, file_name):
         # Duplicate captured data on stdout
         sys.stdout.write(capture)
         with open(gold_txt, 'r') as gold_file:
-            gold = gold_file.read()
+            gold = gold_file.read().strip()
         print('Comparing beebasm output to', gold_txt, end = '')
         if capture.find(gold) != -1:
             print(' succeeded')
@@ -199,4 +199,3 @@ try:
 except TestFailure as e:
     print("FAILURE: " + e.args[0], file = original_stdout)
     sys.exit(1)
-


### PR DESCRIPTION
Adds two new directives which can create and update variables whose names are constructed dynamically. These are primarily intended for use in macros for things such as defining sets of hardware registers or auto-allocating workspace.

